### PR TITLE
PRD v2 + plan d'implémentation V1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## État du projet
+
+Repo en amorçage : il ne contient pour l'instant que le PRD, un README, et la config sources (`sources/comptes.json`). Les répertoires `scripts/`, `templates/`, et `output/` annoncés dans le README n'existent pas encore — à créer au premier commit de code. Aucune toolchain Python n'est en place (pas de `pyproject.toml`, `requirements.txt`, ni tests). Le runtime cible est Python 3.11+.
+
+## Architecture cible
+
+Pipeline quotidien exécuté par **Hermes Agent** (hôte externe à ce repo) via le skill `briefing-matinal`. Ce repo fournit la config + les scripts ; Hermes fournit le cron, les secrets, l'envoi Telegram, et le NAS.
+
+Flux : `sources/comptes.json` → `scripts/build-briefing.py` (interroge xAI Grok `x_search` via `/v1/responses` + `web_search` Hermes en parallèle) → rendu via `templates/briefing.html` → fichier HTML standalone dans `output/YYYY-MM-DD.html` → Hermes envoie sur Telegram à 6h45 AM (America/Toronto), fallback NAS `/mnt/nas/commun/briefing-matinal/`.
+
+Les sections du briefing (AI/Tech, Tesla, SpaceX, Santé, Politique, Business + "En 60 secondes" et "À ne pas manquer") sont **data-driven** depuis `comptes.json` (clé `sections`, avec `max_items` par section). Toute modification de portée (comptes X, thèmes de recherche, sources web) passe par `comptes.json`, pas par le code.
+
+## Contraintes dures (non négociables)
+
+- **HTML standalone** : inline CSS uniquement, pas de CDN, pas de JS, pas de Google Fonts — polices système.
+- **Taille max 50 KB** (limite document Telegram).
+- **Mobile-first**, lisible en dark ET light.
+- **Latence < 3 min** pour la génération complète.
+- **Budget** ~0.10-0.15 $/jour (3-5 appels Grok max).
+- **Output gitignored** (`output/`), comme `.env` et `__pycache__/`.
+
+## Non-goals explicites (voir PRD §Non-goals)
+
+Pas de posting X, pas de résumé vidéo YouTube, pas d'analyse de sentiment, pas de dashboard web, pas de multi-utilisateur. Ne pas fusionner avec le skill `bst-veille-hebdo` (veille pro, séparée).
+
+## Références
+
+- **PRD.md** — source de vérité pour les specs fonctionnelles (S1–S5), les contraintes techniques, et les critères de succès.
+- **sources/comptes.json** — config runtime (15 comptes X, 8 recherches thématiques, 3 sources web, 6 sections).

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,572 @@
+# Plan d'implémentation — Briefing Matinal V1
+
+> Ce document détaille l'ordre et la structure d'implémentation de la V1 du pipeline, tel que spécifié dans `PRD.md` v2. Il est destiné à être relu avant chaque commit pour s'assurer qu'on reste dans le scope.
+
+## Contexte
+
+- **PRD source** : `PRD.md` (v2, commit `5a61521`)
+- **Stack** : Python 3.11+, Jinja2, FastAPI (redirector), SQLite (tracking)
+- **Exécution** : hermes-agent orchestre, ce repo fournit scripts + config
+- **Budget V1** : ~0.35-0.40 $/jour, latence < 3 min par briefing
+
+## Principes directeurs
+
+1. **Offline-first** — toute la logique (ranking, dédup, rendu, contrat stdout) doit tourner sans appel API, via fixtures. On branche xAI en phase 3, pas avant.
+2. **Chaque phase se termine par un artefact testable** — jamais "à moitié fini" entre deux phases.
+3. **Le `--dry-run` est disponible dès la phase 1** — on ne spamme jamais le vrai Telegram/NAS pendant le dev.
+4. **Pas d'optimisation prématurée** — V1 vise la correctness, pas la perf. On profile seulement si on frôle les 3 min de budget latence.
+5. **Commits atomiques par phase** — chaque phase = 1 à 3 commits max, pas de PR monstre.
+
+## Chemin critique
+
+```
+Phase 0 (scaffolding)
+    ↓
+Phase 1 (pipeline offline avec fixtures)  ← Milestone 1 : HTML généré sans API
+    ↓
+Phase 2 (template Jinja2 final)           ← Milestone 2 : briefing visuellement OK
+    ↓
+Phase 3 (intégration xAI)                 ← Milestone 3 : briefing avec vraies données
+    ↓
+Phase 4 (redirector + tracking)           ← Milestone 4 : liens cliquables trackés
+    ↓
+Phase 5 (intégration hermes-agent)        ← Milestone 5 : contrat script↔harness OK
+    ↓
+Phase 6 (tests & validation)              ← Milestone 6 : suite de tests verte
+    ↓
+Phase 7 (mise en service V1)              ← Milestone 7 : prod, cron actif
+```
+
+Phases 1 et 2 peuvent se chevaucher si besoin. Phase 4 (redirector) est indépendante et peut être démarrée en parallèle de la Phase 3 par un autre dev/agent. Tout le reste est séquentiel.
+
+---
+
+## Phase 0 — Scaffolding
+
+**Objectif** : poser la structure du repo et les dépendances sans écrire de logique métier.
+
+### Livrables
+
+| Fichier | Contenu |
+|---|---|
+| `pyproject.toml` | Projet Python avec deps pinnées, `ruff` + `pytest` en dev |
+| `.python-version` | `3.11` (pour pyenv/asdf) |
+| `.env.example` | Template des env vars (`XAI_API_KEY=`, `BRIEFING_ENV=`, `TAILNET_HOSTNAME=`) |
+| `.gitignore` (update) | Ajouter `*.db`, `.venv/`, `.pytest_cache/`, `.ruff_cache/` |
+| `scripts/` | Dossier vide avec `__init__.py` |
+| `templates/` | Dossier vide |
+| `prompts/` | Dossier vide |
+| `tests/fixtures/` | Dossier vide |
+| `sources/comptes.schema.json` | JSON Schema draft 2020-12 valide `comptes.json` |
+| `README.md` (update) | Ajout section "Développement" (install, run, test) |
+
+### Dépendances Python pinnées
+
+```toml
+[project]
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27,<1.0",
+    "jinja2>=3.1,<4.0",
+    "pydantic>=2.7,<3.0",
+    "python-slugify>=8.0,<9.0",  # pour normalisation titres dans dédup
+]
+
+[project.optional-dependencies]
+redirector = [
+    "fastapi>=0.110,<1.0",
+    "uvicorn[standard]>=0.29,<1.0",
+]
+dev = [
+    "pytest>=8.0,<9.0",
+    "pytest-httpx>=0.30,<1.0",  # mock xAI
+    "ruff>=0.4,<1.0",
+    "mypy>=1.10,<2.0",
+]
+```
+
+### Acceptance criteria
+
+- [ ] `python -m venv .venv && source .venv/bin/activate && pip install -e ".[dev,redirector]"` passe sans erreur
+- [ ] `pytest` tourne (collecte 0 tests, c'est normal)
+- [ ] `ruff check .` passe (pas encore de code)
+- [ ] `python -c "import json, jsonschema; jsonschema.validate(json.load(open('sources/comptes.json')), json.load(open('sources/comptes.schema.json')))"` passe
+
+### Commits suggérés
+
+1. `chore: bootstrap python project (pyproject, venv, gitignore)`
+2. `chore: scaffold directories (scripts, templates, prompts, tests)`
+3. `feat(config): add JSON schema for comptes.json + schema_version`
+
+---
+
+## Phase 1 — Pipeline offline avec fixtures
+
+**Objectif** : produire un HTML de briefing complet à partir de fixtures JSON, sans aucun appel externe. **C'est le milestone le plus important de V1** — si ça marche ici, le reste est du branchement.
+
+### Livrables
+
+| Fichier | Rôle |
+|---|---|
+| `scripts/models.py` | Dataclasses `Item`, `Briefing` (voir PRD §Data model) |
+| `scripts/config.py` | Chargement + validation de `comptes.json` contre le schema |
+| `scripts/window.py` | Calcul des fenêtres temporelles matin/soir (pure function) |
+| `scripts/dedup.py` | Logique de dédup (URL canonique + hash titre) |
+| `scripts/select.py` | Sélection `max_items` par section + sections "hero" (60s, dont_miss) |
+| `scripts/render.py` | Wrapper Jinja2 autour de `templates/briefing.html` |
+| `scripts/build_briefing.py` | Entrée CLI avec `argparse`, orchestrateur |
+| `tests/fixtures/x_search_sample.json` | ~30 posts X fake répartis sur tous les comptes/thèmes |
+| `tests/fixtures/web_search_sample.json` | ~15 résultats web fake |
+| `templates/briefing.html` | **Placeholder minimal** (phase 2 polira) |
+
+### Logique du CLI
+
+```bash
+python -m scripts.build_briefing \
+    --moment matin \
+    --fixture tests/fixtures/x_search_sample.json \
+    --fixture tests/fixtures/web_search_sample.json \
+    --dry-run
+```
+
+Comportement :
+1. Valide `sources/comptes.json`
+2. Charge les fixtures comme si c'étaient des retours xAI
+3. Applique filtres qualité (engagement min, exclure replies, etc.)
+4. Dédup
+5. Sélectionne `max_items` par section + 3 items "60 secondes" + 1 "à ne pas manquer"
+6. Rend le HTML via Jinja2 (template placeholder OK à ce stade)
+7. Écrit `output/YYYY-MM-DD-matin.html`
+8. Print JSON stdout : `{"status": "ok", "path": "...", "briefing_id": "...", "items_count": N}`
+9. `--dry-run` = n'écrit PAS sur disque, print le HTML tronqué sur stderr pour inspection
+
+### Acceptance criteria
+
+- [ ] Le CLI produit un HTML non vide
+- [ ] Le JSON stdout est parseable et contient tous les champs attendus
+- [ ] La dédup marche : fixture avec 2 items même URL → 1 item, `alt_sources` peuplé
+- [ ] La sélection respecte `max_items` par section
+- [ ] Idempotence : 2 runs consécutifs avec mêmes fixtures produisent exactement le même HTML (bit-à-bit)
+- [ ] Latence < 1s pour la phase offline (tout sauf rendu Jinja)
+
+### Risques / gotchas
+
+- **Timezone** : toute la logique de fenêtre temporelle doit utiliser `zoneinfo.ZoneInfo("America/Toronto")`, pas UTC
+- **Dédup cross-sections** : un item Tesla peut matcher aussi Business — règle PRD §S1 : le placer dans la plus spécifique
+- **Ordre stable** : pour garantir l'idempotence, trier par `(score DESC, published_at DESC, id ASC)` partout
+
+### Commits suggérés
+
+1. `feat(models): add Item and Briefing dataclasses`
+2. `feat(config): load and validate comptes.json`
+3. `feat(window): compute morning/evening time windows`
+4. `feat(dedup): canonical URL + title-hash dedup`
+5. `feat(select): section quota + hero section selection`
+6. `feat(render): minimal Jinja2 rendering pipeline`
+7. `feat(cli): build_briefing entry point with --dry-run and --fixture`
+8. `test(fixtures): sample X + web search fixtures for offline runs`
+
+---
+
+## Phase 2 — Template HTML final
+
+**Objectif** : transformer le placeholder Phase 1 en template production-ready : mobile-first, dark/light auto, accessibilité AA, budget lisibilité ~50 KB.
+
+### Livrables
+
+| Fichier | Rôle |
+|---|---|
+| `templates/briefing.html` | Template Jinja2 final |
+| `templates/partials/_item.html` | Macro Jinja pour un item (réutilisé par toutes les sections) |
+| `templates/partials/_section.html` | Macro pour une section standard |
+| `templates/partials/_hero.html` | Macro pour "EN 60 SECONDES" et "À NE PAS MANQUER" |
+| `scripts/render.py` (update) | Ajout validation taille + contraste |
+| `tests/test_render.py` | Golden tests sur le HTML produit |
+
+### Design constraints (rappel PRD §S2)
+
+- **Inline CSS** dans un `<style>` unique en `<head>` (pas d'attributs `style=""` éparpillés, maintenabilité)
+- **Polices système** : `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`
+- **Auto dark/light** via `@media (prefers-color-scheme: dark)`
+- **Contraste AA** : ≥ 4.5:1 sur texte normal, ≥ 3:1 sur large text
+- **Font-size ≥ 15px** sur mobile
+- **Emoji natifs** (pas d'images/SVG)
+- **Pas de JS**, pas de CDN, pas de Google Fonts
+- **Pas d'images** dans le briefing V1 (source : PRD non-goals clarifié)
+
+### Structure visuelle du template
+
+```
+<header>
+  ☀️ BRIEFING MATIN — vendredi 19 avril 2026
+</header>
+
+<section class="sixty-seconds">
+  ⚡ EN 60 SECONDES
+  [3 items en style compact "bullet-like"]
+</section>
+
+<section class="standard" id="ai-tech">
+  🤖 AI / Tech
+  [items via macro _item.html]
+</section>
+... (tesla, spacex, sante, politique, business)
+
+<section class="dont-miss">
+  📌 À NE PAS MANQUER
+  [1 item "mis en valeur", avec indication de durée si vidéo]
+</section>
+
+<footer>
+  ⚙️ briefing_id · config_hash · git_commit · prompts_version
+</footer>
+```
+
+### Validation au rendu
+
+Dans `render.py`, après rendu Jinja, vérifier :
+
+1. **Taille** : `len(html.encode("utf-8")) < 50_000` → sinon warning stderr (pas bloquant)
+2. **HTML valide** : parse avec `html.parser` stdlib, pas d'erreur
+3. **Pas de CDN résiduel** : regex `https?://.*\.(googleapis|cloudflare|jsdelivr)` → si match, fail build
+4. **Liens vers redirector** : tous les `<a href>` doivent pointer vers le tailnet hostname (en phase 4 on vérifie ça strictement, pour l'instant on accepte les URLs brutes en mode fixture)
+
+### Acceptance criteria
+
+- [ ] Rendu visuel cohérent dans iOS Telegram (dark + light) — test manuel en phase 7
+- [ ] Taille < 50 KB pour un briefing "plein" (16 items max)
+- [ ] Golden test : HTML rendu avec fixtures stables est bit-à-bit identique entre runs
+- [ ] Contraste validé par outil tiers (ex. `axe-core` CLI ou vérif manuelle des couleurs hex)
+- [ ] Template lisible en désactivant CSS (structure sémantique propre : `<header>`, `<section>`, `<article>`)
+
+### Commits suggérés
+
+1. `feat(templates): base layout with dark/light auto and inline CSS`
+2. `feat(templates): item macro with source attribution and multi-source tag`
+3. `feat(templates): hero sections (60s + dont-miss)`
+4. `feat(render): size and CDN validation hooks`
+5. `test(render): golden tests against fixture briefing`
+
+---
+
+## Phase 3 — Intégration xAI Grok Responses API
+
+**Objectif** : remplacer les fixtures par de vrais appels à l'API xAI. On garde le mode fixture pour les tests et le dev offline.
+
+### Livrables
+
+| Fichier | Rôle |
+|---|---|
+| `scripts/xai_client.py` | Wrapper `httpx` autour de `POST /v1/responses` |
+| `prompts/system.txt` | Prompt système commun à tous les appels |
+| `prompts/x_search_accounts.txt` | Template prompt pour recherche sur comptes X |
+| `prompts/x_search_theme.txt` | Template prompt pour recherche thématique X |
+| `prompts/web_search.txt` | Template prompt pour recherche web |
+| `prompts/rank.txt` | Prompt de ranking quand on excède `max_items` |
+| `prompts/brief_60s.txt` | Prompt pour composer "EN 60 SECONDES" |
+| `prompts/dont_miss.txt` | Prompt pour choisir "À NE PAS MANQUER" |
+| `scripts/sourcing.py` | Orchestrateur des appels parallèles (accounts + themes + web) |
+| `scripts/errors.py` | Retry logic, backoff, dégradation gracieuse |
+| `tests/test_xai_client.py` | Tests avec `pytest-httpx` (mocks) |
+
+### Contrat `xai_client.py`
+
+```python
+class XAIClient:
+    def __init__(self, api_key: str, model: str = "grok-4-1-fast-latest"):
+        ...
+
+    def x_search(
+        self,
+        prompt: str,
+        allowed_handles: list[str] | None = None,   # max 10
+        from_date: date | None = None,
+        to_date: date | None = None,
+        timeout: float = 30.0,
+    ) -> XAIResponse:
+        """Un appel à /v1/responses avec tool x_search."""
+        ...
+
+    def web_search(
+        self,
+        prompt: str,
+        allowed_domains: list[str] | None = None,
+        from_date: date | None = None,
+        to_date: date | None = None,
+        timeout: float = 30.0,
+    ) -> XAIResponse:
+        ...
+```
+
+Chaque appel :
+- Log structuré JSON sur stderr : `{"event": "xai_call", "tool": "x_search", "tokens_in": N, "tokens_out": M, "duration_ms": D, "cost_usd": C}`
+- Retry : 2 tentatives avec backoff `2s, 8s` sur 5xx / timeout
+- Sur 429 : backoff 60s + 1 retry
+- Sur échec persistant : lève `XAIUnavailable(tool, reason)` — le caller choisit de dégrader
+
+### Gestion des 15 comptes X
+
+`allowed_x_handles` est limité à 10/call. Stratégie :
+- Split des 15 comptes en 2 appels (par exemple : 8 AI+Tesla+SpaceX, puis 7 Santé+Business+Politique)
+- Le grouping est configurable dans `comptes.json` via un champ optionnel `comptes_x_groups` (si absent : split équitable auto)
+
+### Mode fixture vs mode live
+
+Le CLI `build_briefing.py` détecte :
+- `--fixture <path>` → mode offline, bypass `XAIClient`
+- Aucune fixture + `XAI_API_KEY` présent → mode live
+- Aucune fixture + pas de clé → erreur explicite, exit 2
+
+### Acceptance criteria
+
+- [ ] Un briefing "live" complet réussit en < 3 min wall-clock
+- [ ] Coût mesuré d'un briefing réel ≈ 0.15-0.20 $ (tokens + tool fees)
+- [ ] Les prompts sont versionnés (`prompts-v1.0`) et le hash est injecté dans le HTML
+- [ ] En cas de panne xAI simulée (mock 503) : le briefing continue avec un warning en header, aucune erreur fatale
+- [ ] Les logs structurés sont parseables par `jq`
+
+### Commits suggérés
+
+1. `feat(xai): httpx client for Responses API with retry/backoff`
+2. `feat(prompts): versioned prompts with include directive support`
+3. `feat(sourcing): parallel orchestration of x_search + web_search`
+4. `feat(errors): graceful degradation on tool unavailability`
+5. `test(xai): mock-based unit tests (pytest-httpx)`
+6. `feat(cli): switch between fixture and live modes`
+
+---
+
+## Phase 4 — Redirector + tracking (Tailscale)
+
+**Objectif** : déployer le service FastAPI qui raccourcit les URLs et logge les clics. Indépendante des phases 1-3 — peut se faire en parallèle.
+
+### Livrables
+
+| Fichier | Rôle |
+|---|---|
+| `scripts/redirector.py` | Service FastAPI (routes `/b/:short_id`, `/stats`, `/healthz`) |
+| `scripts/shortlinks.py` | Lib partagée : génération `short_id` + upsert SQLite (utilisée aussi par `build_briefing.py`) |
+| `scripts/migrations/001_init.sql` | Schema SQLite initial (`short_links`, `clicks`) |
+| `scripts/redirector.service` | Unit systemd template (pour déploiement hermes-agent) |
+| `tests/test_redirector.py` | Tests FastAPI avec `TestClient` |
+
+### Schema SQLite
+
+```sql
+CREATE TABLE short_links (
+    short_id      TEXT PRIMARY KEY,       -- 8 chars base62
+    target_url    TEXT NOT NULL,
+    briefing_id   TEXT NOT NULL,          -- "2026-04-19-matin"
+    section_id    TEXT NOT NULL,
+    item_title    TEXT NOT NULL,
+    created_at    TEXT NOT NULL           -- ISO 8601 UTC
+);
+
+CREATE TABLE clicks (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    short_id      TEXT NOT NULL REFERENCES short_links(short_id),
+    clicked_at    TEXT NOT NULL,
+    user_agent    TEXT
+);
+
+CREATE INDEX idx_clicks_short_id ON clicks(short_id);
+CREATE INDEX idx_clicks_at ON clicks(clicked_at);
+```
+
+### Déploiement Tailscale
+
+- Service bind sur `tailscale0` uniquement (pas `0.0.0.0`)
+- HTTPS via `tailscale cert hermes.<tailnet>.ts.net` au setup initial (manuel une fois)
+- Systemd unit redémarre auto après crash
+- Purge mensuelle des clics > 12 mois via cron simple (`DELETE FROM clicks WHERE clicked_at < date('now', '-12 months')`)
+
+### Acceptance criteria
+
+- [ ] `curl -k https://hermes.<tailnet>.ts.net/b/<id>` depuis laptop sur tailnet → 302 vers target
+- [ ] Même curl depuis device hors tailnet → DNS ne résout pas (comportement attendu)
+- [ ] 100 requêtes concurrentes : toutes loggées, aucune perdue (test avec `httpx` async dans les tests)
+- [ ] `/stats?from=...&to=...` retourne JSON avec counts par section
+- [ ] `/healthz` retourne 200 si SQLite accessible
+
+### Commits suggérés
+
+1. `feat(db): SQLite schema and migrations`
+2. `feat(shortlinks): short_id generation + upsert lib`
+3. `feat(redirector): FastAPI service with redirect and stats`
+4. `chore(deploy): systemd unit for redirector`
+5. `test(redirector): integration tests with TestClient`
+
+---
+
+## Phase 5 — Intégration hermes-agent
+
+**Objectif** : brancher le pipeline sur le cron hermes-agent, valider le contrat stdout JSON, activer le fallback NAS.
+
+### Livrables
+
+| Fichier | Rôle |
+|---|---|
+| `scripts/build_briefing.py` (update) | Respect strict du contrat JSON stdout + exit codes |
+| `scripts/hermes_contract.md` | Doc du contrat script↔hermes (exit codes, stdout, stderr, env vars) |
+| `docs/deployment.md` | Runbook de déploiement côté hermes-agent (cron, secrets, NAS mount) |
+
+### Contrat script → hermes-agent
+
+**Env vars attendues** :
+- `XAI_API_KEY` — requis en mode live
+- `BRIEFING_ENV` — `production` | `staging` | `dry-run`
+- `TAILNET_HOSTNAME` — ex. `hermes.chris-boulet.ts.net`
+- `TELEGRAM_CHAT_ID` — passé à hermes uniquement, pas au script
+- `NAS_PATH` — ex. `/mnt/nas/commun/briefing-matinal`
+
+**Exit codes** :
+| Code | Sens | Action hermes |
+|---|---|---|
+| 0 | Succès, HTML écrit | Lire stdout JSON, envoyer Telegram |
+| 2 | Config invalide (schema fail, no API key) | Alerter Chris, pas de retry |
+| 3 | NAS indisponible ET Telegram aussi | Email inline du HTML |
+| 4 | Budget tokens dépassé | Alerter + pas de retry ce cycle |
+| ≠0 autre | Erreur inattendue | 1 retry dans 5 min, sinon alerter |
+
+**Stdout JSON (succès)** :
+```json
+{
+  "status": "ok",
+  "path": "output/2026-04-19-matin.html",
+  "briefing_id": "2026-04-19-matin",
+  "items_count": 14,
+  "warnings": ["x_search theme=Politique US returned 0 results"]
+}
+```
+
+### Acceptance criteria
+
+- [ ] Hermes peut lancer le script, parser le JSON, envoyer le HTML, sans intervention
+- [ ] Mode `dry-run` ne spamme pas Telegram (testé explicitement)
+- [ ] Fallback NAS testé : débrancher Telegram temporairement, vérifier dépôt NAS
+- [ ] Latence mesurée sur la machine hermes-agent < 3 min (briefing moyen)
+
+### Commits suggérés
+
+1. `feat(contract): strict stdout JSON + exit codes`
+2. `docs(deploy): hermes-agent runbook and env vars`
+3. `feat(fallback): NAS deposit on Telegram failure`
+
+---
+
+## Phase 6 — Tests & validation
+
+**Objectif** : suite de tests verte, couvrant les cas tordus + un test end-to-end avec fixtures.
+
+### Livrables
+
+| Fichier | Rôle |
+|---|---|
+| `tests/test_config.py` | Validation schema `comptes.json` |
+| `tests/test_window.py` | Fenêtres temporelles (matin, soir, DST edge) |
+| `tests/test_dedup.py` | Dédup URL + titre, cross-section |
+| `tests/test_select.py` | Quotas, ordre stable, empty section |
+| `tests/test_render.py` | Golden tests + taille + pas de CDN |
+| `tests/test_e2e_offline.py` | Pipeline complet avec fixtures → HTML → JSON stdout |
+| `tests/conftest.py` | Fixtures pytest partagées |
+
+### Couverture ciblée
+
+- **Logique métier** (dedup, select, window) : **100 %** de lignes
+- **I/O** (xai_client, render) : ≥ 80 % (le reste c'est happy path trivial)
+- **Redirector** : tests d'intégration, pas de cible de couverture stricte
+
+### Tests "pièges" à ne pas oublier
+
+- Briefing avec 0 item (journée calme) → message fallback, pas d'erreur
+- 2 items strictement identiques dans la même fenêtre (repost exact) → 1 seul item
+- `max_items=0` pour une section → section skippée du rendu, pas vide
+- URL avec paramètres trackers (`?utm_source=...`) → canonicalisation les retire
+- DST switch mars/novembre → fenêtre ne saute pas une heure
+- Emoji dans un titre → pas d'échappement cassé
+
+### Acceptance criteria
+
+- [ ] `pytest` passe, 0 skip non justifié
+- [ ] `ruff check` + `mypy` propres
+- [ ] Test e2e offline tourne en < 5s
+
+---
+
+## Phase 7 — Mise en service V1
+
+**Objectif** : premier envoi réel à Chris, monitoring actif 2 semaines.
+
+### Checklist de go-live
+
+- [ ] Cron hermes-agent programmé : 6h44:45 et 17h29:45 America/Toronto
+- [ ] `XAI_API_KEY` injectée par hermes-agent au runtime
+- [ ] Redirector up, `tailscale status` montre le hostname OK
+- [ ] HTTPS cert Tailscale actif (`curl -I https://hermes.<tailnet>.ts.net/healthz` → 200)
+- [ ] Chat Telegram de prod configuré dans hermes-agent
+- [ ] Chat Telegram de test configuré (pour `BRIEFING_ENV=staging`)
+- [ ] NAS monté et accessible en écriture par hermes-agent
+- [ ] Premier `--dry-run` validé visuellement par Chris (HTML ouvert dans navigateur)
+- [ ] Premier run `staging` validé sur chat de test
+- [ ] Premier run `production` lancé manuellement hors cycle cron pour observer
+- [ ] Cron activé
+
+### Monitoring 2 premières semaines
+
+- Vérif quotidienne des logs hermes-agent (erreurs, latence, coût)
+- Chris tient un `FEEDBACK.md` dans le repo : ajustements proposés, items trouvés non pertinents, comptes/thèmes à changer
+- Coût réel vs budget : si > 0.50 $/jour, investigate (trop de tool calls ? modèle trop gros ?)
+- Clics mesurés via `/stats` : cible ≥ 1 clic/briefing en moyenne après semaine 2
+
+### Décisions à prendre en fin de période 2 semaines
+
+- Rester sur `grok-4-1-fast-latest` ou escalader vers `grok-4.20-latest` ?
+- Ajuster `max_items` par section selon feedback Chris ?
+- Ajouter/retirer des comptes ou thèmes ?
+- Passer à la V1.5 (features type breaking news, fallback b64) ?
+
+---
+
+## Dépendances inter-phases
+
+```
+Phase 0  ──────┬──→ Phase 1 ──→ Phase 2 ──→ Phase 3 ──┐
+               │                                       ├──→ Phase 5 ──→ Phase 6 ──→ Phase 7
+               └──→ Phase 4 ───────────────────────────┘
+```
+
+- **Phase 4 peut démarrer dès la fin de Phase 0** — elle n'a besoin que du scaffolding
+- **Phase 5 dépend de Phase 3 ET Phase 4** — il faut les deux pour câbler le contrat
+- **Phase 6 peut commencer pendant Phase 2** pour les tests unitaires, mais le e2e attend Phase 3+
+
+## Questions ouvertes à trancher en cours de route
+
+1. **Prompt language** : prompts LLM en FR ou EN ? EN probablement plus efficace pour Grok, mais outputs en FR-QC requis. → Décision : **prompts en EN, instruction explicite "respond in Quebec French"** dans le system prompt. À valider au premier vrai run.
+2. **Gestion des citations X anglophones** : garder tel quel (bilinguisme assumé) ou reformuler en FR ? → Décision PRD : **garder tel quel**. Jamais de traduction automatique.
+3. **"À ne pas manquer" quand les sources sont pauvres** : que faire si aucun candidat clair ? → Proposition : omettre la section ce briefing-là, mettre une note discrète en footer. À trancher après premiers runs.
+4. **Retry sur le cron** : si run de 6h45 échoue, hermes-agent réessaye à 6h50 ? 7h00 ? Jamais ? → Proposition : **1 retry à +5 min, sinon NAS fallback + alerte**. À confirmer avec Chris.
+
+## Estimation globale (ordre de grandeur)
+
+| Phase | Charge | Parallélisable |
+|---|---|---|
+| 0 — Scaffolding | 1-2 h | non |
+| 1 — Pipeline offline | 4-6 h | non |
+| 2 — Template HTML | 3-5 h | oui (avec 1) |
+| 3 — Intégration xAI | 4-6 h | non |
+| 4 — Redirector | 2-4 h | oui (avec 1-3) |
+| 5 — Intégration hermes | 2-3 h | non |
+| 6 — Tests | 3-5 h | partiellement (au fil) |
+| 7 — Mise en service | 1-2 h actif + 2 semaines de monitoring | — |
+
+**Total dev actif** : ~20-30 h étalées sur 1-2 semaines réelles, monitoring 2 semaines post-lancement.
+
+---
+
+## Critères de "V1 terminée"
+
+- [ ] Chris reçoit 2 briefings/jour à 6h45 et 17h30 pendant 7 jours consécutifs sans intervention manuelle
+- [ ] Coût moyen < 0.50 $/jour
+- [ ] Au moins 1 clic tracké par briefing en moyenne (semaine 2)
+- [ ] Chris rapporte qu'il ouvre le briefing avant de scroller X le matin
+- [ ] Aucun échec non récupéré (Telegram OU NAS livre toujours)

--- a/PRD.md
+++ b/PRD.md
@@ -324,7 +324,7 @@ python scripts/build-briefing.py --moment matin --fixture tests/fixtures/2026-04
 
 - **Runtime** : Python 3.11+ (machine Hermes)
 - **Template** : Jinja2 (décision figée)
-- **API xAI** : **Responses API** (recommandée par xAI, la Chat Completions est legacy/deprecated) — `POST https://api.x.ai/v1/responses`, auth `Authorization: Bearer <clé>` (clé dans OpenClaw secrets). L'ancienne Live Search API (`search_parameters` sur `/v1/chat/completions`) est **dépréciée depuis 2026-01-12** (410 Gone). On utilise les tools server-side `x_search` et `web_search` passés dans le champ `tools`.
+- **API xAI** : **Responses API** (recommandée par xAI, la Chat Completions est legacy/deprecated) — `POST https://api.x.ai/v1/responses`, auth `Authorization: Bearer <clé>` (clé gérée par hermes-agent, injectée dans l'env du script au runtime via `XAI_API_KEY`). L'ancienne Live Search API (`search_parameters` sur `/v1/chat/completions`) est **dépréciée depuis 2026-01-12** (410 Gone). On utilise les tools server-side `x_search` et `web_search` passés dans le champ `tools`.
 - **Doc canonique de référence** : https://docs.x.ai/overview — toute évolution d'endpoint/modèle vérifiée là en premier.
 - **Modèle** : alias **`grok-4-1-fast-latest`** par défaut (optimisé agentic tool calling, pricing bas ~0.20 $/M input, 0.50 $/M output). Escalade vers **`grok-4.20-latest`** (flagship, meilleur taux d'hallucination, strict prompt adherence) uniquement si la qualité de triage n'est pas satisfaisante après 2 semaines d'utilisation. Usage d'alias `-latest` = upgrades automatiques.
 - **Mode d'appel** : stateless (on ne persiste pas côté xAI — chaque briefing est indépendant, pas besoin du mode stateful de la Responses API).

--- a/PRD.md
+++ b/PRD.md
@@ -48,9 +48,9 @@ Le pipeline interroge 3 types de sources en parallèle pour chaque briefing :
 
 | Source | Méthode | Données |
 |---|---|---|
-| Comptes X surveillés | xAI Grok `x_search` | Posts des comptes de la liste dans la fenêtre |
-| Recherche X thématique | xAI Grok `x_search` | Requêtes thématiques (Tesla, SpaceX, santé, etc.) |
-| Web | `web_search` (Hermes) | Journaux QC + recherches actualité |
+| Comptes X surveillés | xAI Responses API, tool `x_search` avec `allowed_x_handles` | Posts des comptes de la liste dans la fenêtre (2 appels car max 10 handles/call) |
+| Recherche X thématique | xAI Responses API, tool `x_search` (query libre, sans handle restriction) | Requêtes thématiques (Tesla, SpaceX, santé, etc.) |
+| Web | xAI Responses API, tool `web_search` | Journaux QC + recherches actualité (filtre `allowed_domains` côté prompt) |
 
 **Fenêtres temporelles** (America/Toronto) :
 - **Briefing matin (6h45)** : couvre `[hier 17h30 → aujourd'hui 6h30]` (~13h, majoritairement nocturne)
@@ -317,10 +317,14 @@ python scripts/build-briefing.py --moment matin --fixture tests/fixtures/2026-04
 
 - **Runtime** : Python 3.11+ (machine Hermes)
 - **Template** : Jinja2 (décision figée)
-- **API X** : xAI Grok `x_search` via `/v1/responses` — **endpoint à confirmer** côté xAI (le path peut différer de la convention OpenAI) ; clé dans OpenClaw secrets
-- **API Web** : `web_search` Hermes
+- **API xAI** : **Responses API** (recommandée par xAI, la Chat Completions est legacy/deprecated) — `POST https://api.x.ai/v1/responses`, auth `Authorization: Bearer <clé>` (clé dans OpenClaw secrets). L'ancienne Live Search API (`search_parameters` sur `/v1/chat/completions`) est **dépréciée depuis 2026-01-12** (410 Gone). On utilise les tools server-side `x_search` et `web_search` passés dans le champ `tools`.
+- **Doc canonique de référence** : https://docs.x.ai/overview — toute évolution d'endpoint/modèle vérifiée là en premier.
+- **Modèle** : alias **`grok-4-1-fast-latest`** par défaut (optimisé agentic tool calling, pricing bas ~0.20 $/M input, 0.50 $/M output). Escalade vers **`grok-4.20-latest`** (flagship, meilleur taux d'hallucination, strict prompt adherence) uniquement si la qualité de triage n'est pas satisfaisante après 2 semaines d'utilisation. Usage d'alias `-latest` = upgrades automatiques.
+- **Mode d'appel** : stateless (on ne persiste pas côté xAI — chaque briefing est indépendant, pas besoin du mode stateful de la Responses API).
+- **Paramètres `x_search`** : `allowed_x_handles` (max 10/requête — les 15 comptes sont splittés sur 2 appels), `from_date`/`to_date` (ISO 8601, fenêtre glissante), mutuellement exclusif avec `excluded_x_handles`.
+- **`web_search`** : outil server-side xAI (pas besoin d'un `web_search` externe, on reste dans un seul provider pour simplifier auth + observabilité + facturation).
 - **Tracking** : service FastAPI + SQLite sur même hôte, exposé via nginx Hermes
-- **Budget financier** : ~0.25-0.40 $/jour (2 briefings × 6-10 appels Grok) — alerte si > 15 $/mois
+- **Budget financier** : ~0.35-0.40 $/jour (breakdown : ~0.32 $ tool fees à 5 $/1000 appels × ~16 queries/jour × 3-5 tool calls internes + ~0.05 $ tokens). Alerte si > 15 $/mois.
 - **Budget latence** : < 3 min par briefing (timeout hard 180s)
 - **Budget tokens** : ~100 K tokens/jour max (garde-fou dans le script, abort si dépassé)
 

--- a/PRD.md
+++ b/PRD.md
@@ -196,27 +196,34 @@ Chaque briefing est archivé en deux endroits :
 
 **Ajout d'une nouvelle section** : seulement éditer `sections` + (optionnellement) ajouter des `recherches_thematiques` pointant dessus. Aucun code à toucher si la section suit le pattern standard. Le template Jinja2 itère dynamiquement sur la config.
 
-### S6 — Tracking clics & short-links
+### S6 — Tracking clics & short-links (via Tailscale)
 
-Tous les liens du briefing passent par un **redirector minimal** hébergé sur la même machine Hermes.
+Tous les liens du briefing passent par un **redirector minimal** qui tourne sur la machine hermes-agent et est **exposé uniquement sur le tailnet Chris** (Tailscale). Aucun VPS, aucun port ouvert sur internet public, aucun tunnel Cloudflare nécessaire.
 
 **Architecture** :
-- Service HTTP léger (FastAPI ou équivalent) sur port interne, reverse-proxy via nginx Hermes
+- Service FastAPI (ou équivalent Python léger) sur la machine hermes-agent, bindé sur l'IP Tailscale de la machine (`tailscale0`)
+- Hostname via MagicDNS : `hermes.<tailnet-name>.ts.net` avec **HTTPS** (certs Tailscale auto-provisionnés — éviter http:// qui fait flagguer Telegram/iOS)
 - Route : `GET /b/:short_id` → `302 Redirect` vers l'URL cible
-- Storage : SQLite (`briefing_tracker.db`) — tables `short_links`, `clicks`
+- Storage : SQLite (`~/briefing_tracker.db`) — tables `short_links`, `clicks`
+- Accessibilité : seuls les devices sur le tailnet de Chris (téléphone, laptop) résolvent le hostname et suivent les redirects
 
 **Génération** :
 - Au moment du rendu, chaque URL unique reçoit un `short_id` de 8 chars (base62, dérivé du SHA-256 de l'URL pour idempotence)
 - Le script insère/UPSERT dans `short_links` avec : `short_id`, `target_url`, `briefing_id`, `section_id`, `item_title`, `created_at`
-- Le HTML utilise `https://[hermes-domain]/b/:short_id`
+- Le HTML utilise `https://hermes.<tailnet>.ts.net/b/:short_id`
 
 **Log des clics** :
-- Chaque hit enregistre : `short_id`, `clicked_at`, `user_agent`, IP (tronquée à /24 pour respect vie privée)
-- Pas de cookies, pas de fingerprinting — Chris est seul utilisateur attendu
+- Chaque hit enregistre : `short_id`, `clicked_at`, `user_agent`
+- Pas besoin de logger IP (tout vient du tailnet privé de Chris — un seul utilisateur de toute façon)
+- Pas de cookies, pas de fingerprinting
+
+**Edge case — Tailscale déconnecté** : si Chris clique depuis un device hors tailnet (avion, VPN corpo qui override), le hostname ne résout pas → lien mort. Impact : clic perdu + frustration. Atténuation V1 : accepter (cas rare). V1.5 éventuelle : encoder l'URL cible en base64 dans le path (`/b/:short_id/:b64_fallback`) pour qu'un bookmark local puisse recover même offline.
+
+**Effet de bord désirable** : Telegram tente l'unfurl des URLs depuis **ses serveurs** (pas depuis ton téléphone). Les hostnames `*.ts.net` privés ne résolvent pas côté Telegram → **pas de preview générée**, briefing visuellement plus propre, zéro requête parasite dans les logs de tracking.
 
 **Rétention clics** : 12 mois glissants, purge mensuelle.
 
-**Exposition de la métrique** : un petit endpoint `/stats?from=YYYY-MM-DD&to=YYYY-MM-DD` retourne JSON pour alimenter un futur dashboard ou la PRD v3 ("apprentissage des clics").
+**Exposition de la métrique** : endpoint `/stats?from=YYYY-MM-DD&to=YYYY-MM-DD` (toujours sur tailnet) qui retourne JSON pour alimenter un futur dashboard ou la PRD v3 ("apprentissage des clics").
 
 ### Data model
 

--- a/PRD.md
+++ b/PRD.md
@@ -1,4 +1,7 @@
-# PRD — Briefing Matinal Hermes
+# PRD — Briefing Matinal Hermes (v2)
+
+> **Versions** : v1 (init repo) → **v2 (révision post-analyse, 2026-04-19)**
+> Changements majeurs v2 : cadence 2x/jour, budget "5 min = triage pur", politique unifiée, short-links avec tracking de clics, data model explicite, modes d'erreur documentés, prompts LLM spécifiés.
 
 ## Problème
 
@@ -11,159 +14,332 @@ Chris consomme son actualité de manière passive : scroll X soumis à l'algorit
 
 ## Solution
 
-Un pipeline automatisé qui produit un briefing HTML quotidien, livré sur Telegram à 6h45 AM, couvrant les sujets qui comptent pour Chris — pas ceux que l'algorithme veut lui montrer.
+Un pipeline automatisé qui produit deux briefings HTML par jour (matin + soir), livrés sur Telegram, couvrant les sujets qui comptent pour Chris — pas ceux que l'algorithme veut lui montrer. Chaque briefing est conçu comme un **outil de triage ≤ 5 min**, pas comme une lecture complète. Les liens pertinents alimentent une queue de deep-dives pour le reste de la journée.
 
 ## Utilisateur
 
 **Christian Boulet** — consultant TI (BST), Québec QC
-- Sharp 9h-13h — le briefing doit être prêt avant
+- Sharp 9h-13h — le briefing matin doit être prêt avant
 - Intérêts : AI/Tech, Tesla, SpaceX, santé (longévité, jeûne, ménopause), politique (QC+Canada+US+international), business
 - Consomme sur téléphone (Telegram) — format mobile-first
 - Veut des liens cliquables, pas un mur de texte
+- **Parfaitement bilingue FR-EN** : structure du briefing en français québécois, citations/titres anglophones conservés tels quels (pas de traduction forcée)
 - Apprécie les sources : Cleo Abram, Diary of a CEO, Tom Bilyeu, David Sinclair, Karpathy, Daniel Miessler, CernBasher
+
+## Décisions V1 (log)
+
+Décisions prises lors de la révision du PRD ; elles cadrent la V1 et ne sont pas re-négociables sans passer par v3.
+
+| # | Décision | Valeur |
+|---|---|---|
+| D1 | Cadence | **2x/jour** — 6h45 + 17h30 America/Toronto |
+| D2 | Cadence weekends | **Identique** (sam/dim = 2x/jour) |
+| D3 | Budget lecture | **Triage pur ≤ 5 min** — deep-dives en queue |
+| D4 | Sections politique | **1 section unifiée**, 3 items max |
+| D5 | "À ne pas manquer" | **Dans les deux briefings** (1 item chacun) |
+| D6 | Tracking | **Short-links + log de clics** (redirector dédié) |
+| D7 | Langue | **FR-QC structurel**, bilingue toléré sans traduction |
 
 ## Spécifications fonctionnelles
 
 ### S1 — Sourcing multi-source
 
-Le pipeline doit interroger au moins 3 types de sources en parallèle :
+Le pipeline interroge 3 types de sources en parallèle pour chaque briefing :
 
 | Source | Méthode | Données |
 |---|---|---|
-| Comptes X surveillés | xAI Grok `x_search` | Derniers posts des comptes de la liste |
-| Recherche X thématique | xAI Grok `x_search` | Tesla, SpaceX, santé, politique, business |
-| Web | `web_search` | JDQ, Les Affaires, nouvelles QC/Canada/US, santé |
+| Comptes X surveillés | xAI Grok `x_search` | Posts des comptes de la liste dans la fenêtre |
+| Recherche X thématique | xAI Grok `x_search` | Requêtes thématiques (Tesla, SpaceX, santé, etc.) |
+| Web | `web_search` (Hermes) | Journaux QC + recherches actualité |
 
-**Comptes X surveillés (15) :**
-```
-# AI / Tech
-@karpathy, @DanielMiessler, @AnthropicAI, @OpenAI
+**Fenêtres temporelles** (America/Toronto) :
+- **Briefing matin (6h45)** : couvre `[hier 17h30 → aujourd'hui 6h30]` (~13h, majoritairement nocturne)
+- **Briefing soir (17h30)** : couvre `[aujourd'hui 6h30 → aujourd'hui 17h15]` (~11h, journée complète)
 
-# Tesla / SpaceX
-@cernbasher, @WholeMarsBlog, @SpaceX
+La fenêtre est calculée dynamiquement au lancement ; un lag de 15 min avant l'heure cible sert de tampon de collecte.
 
-# Santé
-@davidasinclair, @PeterAttiaMD, @hubermanlab
+**Filtres de qualité appliqués à tous les posts X** :
+- Exclure les replies (`in_reply_to` non nul)
+- Exclure les retweets purs (préférer le post original si présent)
+- Exclure les posts < 80 caractères (probablement du bruit/meme)
+- Score d'engagement minimal : likes ≥ 50 OU reposts ≥ 10 (paramétrable)
 
-# Science / Découverte
-@CleoAbram
+**Dé-duplication** (appliquée avant rendu) :
+- Clé primaire : URL canonique (domaine + path, query params supprimés sauf `v=` YouTube)
+- Clé secondaire : SHA-1 des 200 premiers caractères du titre normalisé (lowercase, ponctuation supprimée)
+- Si deux items partagent une clé, on garde celui avec le score le plus élevé ; les sources alternatives sont listées en "via ... + N autres"
 
-# Business / Développement
-@DiaryOfACEO, @TomBilyeu
+### S1.bis — Prompts & critères de sélection LLM
 
-# Politique / Canada-QC
-@JDeQuebec, @lesaffaires
-```
+Le LLM (xAI Grok) reçoit pour chaque appel un prompt structuré. Les templates de prompts sont versionnés dans `prompts/` :
 
-La liste est stockée dans `sources/comptes.json` — modifiable sans toucher au code.
+- `prompts/x_search.txt` — recherche sur un compte X ou un thème
+- `prompts/web_search.txt` — recherche web thématique
+- `prompts/rank.txt` — sélection finale par section (si on excède `max_items`)
+- `prompts/brief_60s.txt` — composition des 3 items "EN 60 SECONDES"
+- `prompts/dont_miss.txt` — sélection du "À NE PAS MANQUER"
+
+**Critères de pertinence** (inclus dans tous les prompts de sélection) :
+1. **Signal > bruit** : préférer une annonce concrète (release, chiffre, décision) à une opinion
+2. **Primauté** : une source primaire (compte officiel, communiqué) > une reprise
+3. **Fraîcheur** : dans la fenêtre temporelle, plus récent > plus vieux, toutes choses égales
+4. **Pertinence Chris** : match avec ses intérêts déclarés (cf. section Utilisateur)
+5. **Évitement doublon cross-section** : si un item peut aller dans 2 sections, le placer dans la plus spécifique
+
+**Sélection "EN 60 SECONDES"** : 3 items choisis *après* que toutes les sections sont remplies, parmi l'union des items sélectionnés. Critère : convergence inter-sources (plusieurs sources indépendantes mentionnent le même événement) OU impact mesurable (chiffre, décision réglementaire, launch).
+
+**Sélection "À NE PAS MANQUER"** : 1 item par briefing, choisi dans l'union des items *non retenus* par les sections (pour éviter la redondance). Privilégier : vidéo longue (si matin = queue de la journée) ou thread analytique (si soir = lecture de soirée).
 
 ### S2 — Compilation HTML
 
-Le briefing est un fichier HTML standalone (pas de dépendances externes, inline CSS).
+Le briefing est un fichier HTML standalone rendu par **Jinja2** (décision : pas de string formatting, Jinja2 imposé pour l'auto-escape).
 
-**Sections :**
+**Structure du document** :
 
 ```
-☀️ BRIEFING — [date]
+☀️ BRIEFING MATIN — [jour long FR, date]        (ou 🌙 BRIEFING SOIR)
 ─────────────────────
-⚡ EN 60 SECONDES (3 faits marquants du jour)
+⚡ EN 60 SECONDES                  — 3 faits marquants
 ─────────────────────
-🤖 AI / TECH          — 3-5 items max
-🚗 TESLA              — 2-3 items max
-🚀 SPACEEX            — 1-2 items max
-🏥 SANTÉ              — 2-3 items max
-🏛️ POLITIQUE          — 2-3 items max
-💼 BUSINESS           — 2-3 items max
+🤖 AI / TECH                       — 3 items max
+🚗 TESLA                           — 2 items max
+🚀 SPACEX                          — 1-2 items max
+🏥 SANTÉ                           — 2 items max
+🏛️ POLITIQUE                       — 3 items max (QC+Canada+US+Inter unifié)
+💼 BUSINESS                        — 2 items max
 ─────────────────────
-📌 À NE PAS MANQUER    — 1 recommandation (vidéo, thread, article)
+📌 À NE PAS MANQUER                — 1 item (vidéo / thread / article long)
+─────────────────────
+⚙️ Méta : config hash, briefing_id, version
 ```
 
-**Chaque item :**
-- Titre cliquable (lien vers source)
-- 1-2 lignes de contexte
-- Emoji de catégorie
-- Source indiquée (ex: "via @cernbasher" ou "via JDQ")
+**Volume cible** : ~13-15 items par briefing = ~3-4 min de scan en triage pur. Le matin tend à être légèrement plus court (nuit plus calme), le soir plus dense — c'est naturel, pas besoin de forcer.
 
-**Contraintes design :**
-- Mobile-first (lisible sur Telegram iPhone/Android)
-- Dark-friendly mais lisible en light aussi
-- Inline CSS uniquement (pas de CDN, pas de JS)
-- Taille max : 50KB (limite Telegram)
-- Polices système (pas de Google Fonts)
+**Chaque item** :
+- Titre (cliquable via short-link, cf. S6) — **langue d'origine préservée**
+- 1-2 lignes de contexte en **français québécois**, style télégraphique
+- Emoji de catégorie en préfixe
+- Source indiquée en suffixe (ex : `via @cernbasher` ou `via JDQ`)
+- Si multi-sources convergent : `via @X + 2 autres`
+
+**Contraintes design** :
+- **Mobile-first** — lisible sur Telegram iPhone/Android sans zoom
+- **Auto dark/light** via `prefers-color-scheme` (palette unique neutre en fallback)
+- **CSS inline** (balise `<style>` dans `<head>` OK, pas de fichier externe, pas de CDN)
+- **Pas de JS**, pas de Google Fonts — polices système uniquement
+- **Budget lisibilité ~50 KB** (pas une limite Telegram — limite self-imposée pour scan rapide ; Telegram document accepte 2 GB)
+- **Accessibilité** : contraste AA minimum, taille de police ≥ 15px, liens clairement distincts
 
 ### S3 — Livraison Telegram
 
-Le briefing est livré comme document HTML sur Telegram à 6h45 AM (America/Toronto).
+**Flux** :
+1. Le cron Hermes déclenche le script à `HH-00:00:15` (6h44:45 / 17h29:45) — 15 s de marge réseau
+2. Le script produit `output/YYYY-MM-DD-[matin|soir].html` + écrit sur stdout un JSON :
+   ```json
+   {"status": "ok", "path": "output/2026-04-19-matin.html", "briefing_id": "...", "items_count": 14}
+   ```
+3. Hermes lit le JSON, envoie le HTML comme **document Telegram** au chat de Chris
+4. Hermes attend 200 OK, logge le `message_id` Telegram pour traçabilité
 
-**Méthode :** Le cron Hermes exécute le script, le script génère le HTML, Hermes envoie le fichier via Telegram.
+**Contrat script → Hermes** :
+- Exit code `0` = succès, stdout JSON valide attendu
+- Exit code `≠ 0` = échec, stderr contient le diagnostic
+- Timeout soft : 150 s ; hard : 180 s (Hermes kill au-delà)
 
-**Fallback :** Si Telegram échoue, déposer sur `/mnt/nas/commun/briefing-matinal/YYYY-MM-DD.html`.
+**Fallback en cas d'échec Telegram** :
+1. Dépôt sur NAS : `/mnt/nas/commun/briefing-matinal/YYYY-MM-DD-[matin|soir].html`
+2. Notification Hermes à Chris via canal secondaire (email ou SMS Hermes) : "Briefing du [moment] dispo sur NAS, Telegram a échoué : [raison]"
 
 ### S4 — Archivage
 
-Chaque briefing est archivé :
-- Local : `output/YYYY-MM-DD.html`
-- NAS : `/mnt/nas/commun/briefing-matinal/YYYY-MM-DD.html`
+Chaque briefing est archivé en deux endroits :
 
-Le répertoire `output/` est gitignored.
+- **Local repo** : `output/YYYY-MM-DD-[matin|soir].html` — gitignored
+- **NAS** : `/mnt/nas/commun/briefing-matinal/YYYY-MM-DD-[matin|soir].html`
+
+**Rétention** :
+- Local : rotation 90 jours (cron de cleanup quotidien)
+- NAS : illimité (c'est la trace long terme)
+
+**Versionnage de la config** : chaque HTML archivé contient un commentaire HTML en pied de page avec le **hash SHA-256 de `comptes.json`** au moment du rendu, le **git commit hash** du repo, et la **version des prompts**. Permet de reproduire ou auditer un briefing passé.
 
 ### S5 — Paramètres configurables
 
-`sources/comptes.json` contient :
+`sources/comptes.json` est le fichier unique de configuration runtime. Il est validé au démarrage du script contre `sources/comptes.schema.json` (JSON Schema draft 2020-12) ; échec de validation = exit `2` avec diagnostic.
+
+**Champs** :
+
 ```json
 {
+  "schema_version": 1,
   "comptes_x": ["@karpathy", "@DanielMiessler", ...],
   "recherches_thematiques": [
-    {"theme": "Tesla", "query": "Tesla FSD robotaxi Optimus Cybertruck"},
-    {"theme": "SpaceX", "query": "SpaceX Starship Starlink launch"},
-    {"theme": "Santé", "query": "longevity fasting menopause NMN aging"},
-    {"theme": "Politique Canada", "query": "Canada Quebec politique"},
-    {"theme": "Business", "query": "marchés bourse économie Québec Canada"}
+    {"theme": "Tesla", "query": "...", "section_id": "tesla"},
+    {"theme": "Politique Canada", "query": "...", "section_id": "politique"},
+    {"theme": "Politique US", "query": "...", "section_id": "politique"},
+    {"theme": "Politique International", "query": "...", "section_id": "politique"}
   ],
-  "sources_web": [
-    "journaldequebec.com",
-    "lesaffaires.com",
-    "lapresse.ca"
-  ],
+  "sources_web": ["journaldequebec.com", "lesaffaires.com", "lapresse.ca"],
   "sections": [
-    {"id": "ai-tech", "label": "AI / Tech", "emoji": "🤖", "max_items": 5},
-    {"id": "tesla", "label": "Tesla", "emoji": "🚗", "max_items": 3},
+    {"id": "ai-tech", "label": "AI / Tech", "emoji": "🤖", "max_items": 3},
+    {"id": "tesla", "label": "Tesla", "emoji": "🚗", "max_items": 2},
     {"id": "spacex", "label": "SpaceX", "emoji": "🚀", "max_items": 2},
-    {"id": "sante", "label": "Santé", "emoji": "🏥", "max_items": 3},
+    {"id": "sante", "label": "Santé", "emoji": "🏥", "max_items": 2},
     {"id": "politique", "label": "Politique", "emoji": "🏛️", "max_items": 3},
-    {"id": "business", "label": "Business", "emoji": "💼", "max_items": 3}
-  ]
+    {"id": "business", "label": "Business", "emoji": "💼", "max_items": 2}
+  ],
+  "engagement_min": {"likes": 50, "reposts": 10}
 }
 ```
 
-## Non-goals (ne pas faire)
+**Règle de mapping N→1** : plusieurs `recherches_thematiques.section_id` peuvent pointer vers la même section (ex : les 3 recherches politiques pointent vers `politique`). Le script agrège puis sélectionne `max_items` finaux.
+
+**Ajout d'une nouvelle section** : seulement éditer `sections` + (optionnellement) ajouter des `recherches_thematiques` pointant dessus. Aucun code à toucher si la section suit le pattern standard. Le template Jinja2 itère dynamiquement sur la config.
+
+### S6 — Tracking clics & short-links
+
+Tous les liens du briefing passent par un **redirector minimal** hébergé sur la même machine Hermes.
+
+**Architecture** :
+- Service HTTP léger (FastAPI ou équivalent) sur port interne, reverse-proxy via nginx Hermes
+- Route : `GET /b/:short_id` → `302 Redirect` vers l'URL cible
+- Storage : SQLite (`briefing_tracker.db`) — tables `short_links`, `clicks`
+
+**Génération** :
+- Au moment du rendu, chaque URL unique reçoit un `short_id` de 8 chars (base62, dérivé du SHA-256 de l'URL pour idempotence)
+- Le script insère/UPSERT dans `short_links` avec : `short_id`, `target_url`, `briefing_id`, `section_id`, `item_title`, `created_at`
+- Le HTML utilise `https://[hermes-domain]/b/:short_id`
+
+**Log des clics** :
+- Chaque hit enregistre : `short_id`, `clicked_at`, `user_agent`, IP (tronquée à /24 pour respect vie privée)
+- Pas de cookies, pas de fingerprinting — Chris est seul utilisateur attendu
+
+**Rétention clics** : 12 mois glissants, purge mensuelle.
+
+**Exposition de la métrique** : un petit endpoint `/stats?from=YYYY-MM-DD&to=YYYY-MM-DD` retourne JSON pour alimenter un futur dashboard ou la PRD v3 ("apprentissage des clics").
+
+### Data model
+
+Un **Item** est l'unité de contenu manipulée dans tout le pipeline. Structure canonique :
+
+```python
+@dataclass
+class Item:
+    id: str                    # SHA-1(canonical_url)[:12]
+    title: str                 # Langue d'origine préservée
+    summary: str               # 1-2 lignes FR-QC générées par LLM
+    canonical_url: str         # URL dédupliquée
+    short_url: str             # URL via redirector (rempli au rendu)
+    section_id: str            # Clé FK vers sections[].id
+    source_type: str           # "x_account" | "x_search" | "web"
+    source_handle: str         # "@cernbasher" | "Tesla (search)" | "journaldequebec.com"
+    published_at: datetime     # UTC
+    score: float               # 0.0-1.0, output du ranking LLM
+    raw_excerpt: str           # Bout brut pour audit, non rendu
+    alt_sources: list[str]     # Autres sources si dédupliqué (pour "via X + 2 autres")
+```
+
+Un **Briefing** est la collection finale :
+
+```python
+@dataclass
+class Briefing:
+    briefing_id: str           # "2026-04-19-matin"
+    moment: Literal["matin", "soir"]
+    generated_at: datetime     # UTC
+    window_start: datetime
+    window_end: datetime
+    sixty_seconds: list[Item]  # 3 items
+    sections: dict[str, list[Item]]  # section_id → items triés
+    dont_miss: Item
+    config_hash: str           # SHA-256 de comptes.json
+    prompts_version: str       # ex: "prompts-v1.2"
+    git_commit: str            # 7-char commit du repo
+```
+
+## Modes d'erreur & dégradation
+
+Matrice de comportement face aux pannes externes. Aucune panne ne doit laisser Chris sans briefing ni sans message.
+
+| Panne | Détection | Réaction |
+|---|---|---|
+| xAI Grok 5xx / timeout | HTTP ≥ 500 ou > 30s | 2 retries avec backoff (2s, 8s). Si échec persistant : briefing sans section X, note en entête "⚠️ X indisponible" |
+| xAI quota dépassé | HTTP 429 | Log + backoff 60s + 1 retry. Si persiste : même traitement que 5xx |
+| `web_search` 0 résultat | count == 0 | Pas d'erreur : on saute proprement, section vide skippée dans le rendu |
+| `web_search` timeout | > 20s | 1 retry. Si échec : briefing sans items web, note discrète |
+| Config invalide (schema) | Validation boot | Exit `2`, Hermes alerte Chris immédiatement, pas de briefing envoyé |
+| Telegram 4xx/5xx | send_document ≠ 200 | 1 retry à 5s, puis fallback NAS + notif Hermes |
+| NAS indisponible | mount/write fail | Log d'erreur, ne bloque pas Telegram. Si Telegram aussi down : exit `3`, Hermes envoie le HTML inline par email |
+| Aucun item après filtrage | items_count == 0 global | Briefing minimal avec message "Journée calme — rien de marquant dans la fenêtre. Prochain briefing [HH:MM]." |
+| Redirector down au rendu | HTTP fail sur healthcheck | Fallback : liens directs sans short-link (tracking perdu pour ce briefing, note en pied) |
+
+**Observabilité** :
+- Logs structurés JSON sur stdout → captés par systemd/journald côté Hermes
+- Métriques simples : latence par étape (sourcing, ranking, rendu, envoi), tokens LLM consommés, nombre d'items par section
+- Alerte active si : 2 échecs consécutifs du même briefing OU dépassement budget mensuel (> 15 $)
+
+## Dev/prod & testing
+
+**Séparation des environnements** via variable d'env `BRIEFING_ENV` :
+- `production` — envoi au chat Telegram de Chris, écrit sur NAS, log redirector en SQLite prod
+- `staging` — envoi à un chat Telegram de test (groupe dédié), écrit sur `output/staging/`, SQLite staging
+- `dry-run` — ne poste rien, génère le HTML, print le JSON de sortie, quitte
+
+**Flag CLI** :
+```
+python scripts/build-briefing.py --moment matin --dry-run
+python scripts/build-briefing.py --moment soir --env staging
+python scripts/build-briefing.py --moment matin --fixture tests/fixtures/2026-04-15-matin.json
+```
+
+**Fixtures** : `tests/fixtures/` contient des réponses xAI/web_search enregistrées (replay offline). Permet de tester rendu, dédup, sélection sans appel API réel. Utilisé aussi pour CI (si CI ajoutée plus tard).
+
+**Tests** (à minima pour V1) :
+- Validation schema de `comptes.json`
+- Dédup : 2 items même URL → 1 item avec `alt_sources` peuplé
+- Rendu Jinja2 : HTML valide, contraste, taille < 60 KB
+- Sélection : si N > max_items, top N par score retenu
+- Contrat stdout : JSON parseable avec tous les champs attendus
+
+## Non-goals (V1)
 
 - ❌ Posting automatique sur X
 - ❌ Résumé de vidéos YouTube (trop coûteux/lent pour un quotidien)
 - ❌ Analyse de sentiment ou opinion générée — juste les faits
-- ❌ Interface web / dashboard
+- ❌ Interface web / dashboard (sauf endpoint `/stats` JSON brut pour S6)
 - ❌ Multi-utilisateur — c'est personnel
-- ❌ Remplacer la veille pro BST (skill bst-veille-hebdo reste séparé)
+- ❌ Scraping HTML direct (on passe exclusivement par `web_search`)
+- ❌ Alertes breaking news hors cycle (v2+, cf. Évolution)
+- ❌ Traduction automatique (bilingue assumé, titres EN gardés)
+- ❌ Remplacer la veille pro BST (skill `bst-veille-hebdo` reste séparé)
 
 ## Contraintes techniques
 
-- **Runtime** : Python 3.11+ (sur machine Hermes)
-- **API X** : xAI Grok `x_search` via `/v1/responses` (existant, clé dans OpenClaw secrets)
+- **Runtime** : Python 3.11+ (machine Hermes)
+- **Template** : Jinja2 (décision figée)
+- **API X** : xAI Grok `x_search` via `/v1/responses` — **endpoint à confirmer** côté xAI (le path peut différer de la convention OpenAI) ; clé dans OpenClaw secrets
 - **API Web** : `web_search` Hermes
-- **Template** : Jinja2 ou string formatting Python
-- **Coût** : ~$0.10-0.15/jour en appels xAI (3-5 appels Grok)
-- **Latence** : < 3 minutes total pour générer le briefing
+- **Tracking** : service FastAPI + SQLite sur même hôte, exposé via nginx Hermes
+- **Budget financier** : ~0.25-0.40 $/jour (2 briefings × 6-10 appels Grok) — alerte si > 15 $/mois
+- **Budget latence** : < 3 min par briefing (timeout hard 180s)
+- **Budget tokens** : ~100 K tokens/jour max (garde-fou dans le script, abort si dépassé)
 
 ## Succès mesurable
 
-- Chris lit le briefing 5 matins sur 7
-- Chris arrête de scroll X le matin (remplacé par le briefing)
-- Au moins 1 clic sur un lien par jour
-- Après 2 semaines, Chris a une liste d'ajustements < 5 items
+| Métrique | Cible V1 | Mesure |
+|---|---|---|
+| Briefings livrés à l'heure | ≥ 95 % (2 retards max/mois × 2 briefings) | Log Hermes |
+| Clics par briefing (moyenne) | ≥ 1 | SQLite redirector |
+| Items cliqués / total items | ≥ 5 % | SQLite redirector |
+| Chris arrête de scroll X matin | Self-report hebdo | Conversation |
+| Liste d'ajustements après 2 sem | < 5 items | Fichier `FEEDBACK.md` |
+| Coût mensuel | < 12 $ | Log xAI |
 
 ## Évolution future (v2+)
 
-- Score de pertinence par item (apprentissage des clics)
-- Intégration veille pro BST (sourcing partagé)
-- Alertes instantanées sur sujets critiques (breaking news)
-- Résumé hebdo compilé à partir des briefings quotidiens
+- **Scoring personnalisé** basé sur historique de clics (le tracking V1 alimente ça)
+- **Alertes breaking news** hors cycle (seuil : > 3 comptes surveillés postent sur le même sujet en < 30 min)
+- **Intégration veille pro BST** (sourcing partagé, pas de fusion)
+- **Récap hebdo dimanche soir** compilé à partir des 14 briefings de la semaine
+- **Mode audio** : TTS du briefing matin pour écoute en voiture (9h sharp)
+- **Fine-tuning de la sélection** via RLHF léger sur les réactions Telegram (👍/👎 si ajouté)


### PR DESCRIPTION
## Résumé

Bootstrap du projet : révision complète du PRD (v1 → v2) + plan d'implémentation V1 détaillé en 7 phases.

### PRD v2 (`PRD.md`)

Révision post-analyse critique, intégrant les décisions prises en session :

- **Cadence 2x/jour** (6h45 + 17h30 America/Toronto, weekends inclus)
- **Budget 5 min = triage pur** — briefings denses, deep-dives en queue
- **Politique unifiée** (1 section, 3 items max)
- **Tracking clics via short-links** hébergés sur Tailscale tailnet
- **Structure FR-QC** mais bilingue toléré (titres EN gardés tels quels)
- **xAI Responses API** (`grok-4-1-fast-latest`, escalade possible vers `grok-4.20-latest`)
- **Secrets via hermes-agent** (`XAI_API_KEY` injectée au runtime)
- **Data model** explicite (`Item`, `Briefing`)
- **Modes d'erreur** matricés (10 pannes couvertes)
- **Dev/prod** via `BRIEFING_ENV` + `--dry-run`

### Plan V1 (`PLAN.md`)

7 phases, chemin critique documenté :

0. Scaffolding (pyproject, schema JSON)
1. Pipeline offline avec fixtures — **milestone clé**
2. Template HTML mobile-first + dark/light
3. Intégration xAI Responses API
4. Redirector FastAPI + SQLite sur Tailscale (parallélisable)
5. Intégration hermes-agent (contrat stdout, fallback NAS)
6. Tests & validation
7. Mise en service + monitoring 2 semaines

Estimation : **20-30h dev actif** étalées sur 1-2 semaines.

## Test plan

- [ ] Relecture PRD v2 : cohérence des décisions avec le besoin réel
- [ ] Relecture PLAN.md : ordre des phases, acceptance criteria réalistes
- [ ] Validation des hypothèses sur hermes-agent (env vars, exit codes, NAS mount)
- [ ] Confirmation Tailscale HTTPS certs activables sur la machine hermes-agent

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo