### PR TITLE
docs: preview HTML rendu (sample-matin)

### DIFF
--- a/docs/preview/README.md
+++ b/docs/preview/README.md
@@ -1,0 +1,19 @@
+# Preview HTML
+
+Snapshots de briefings rendus, **uniquement pour visualisation**. Pas de pipeline de prod ne lit ce dossier.
+
+## Voir le rendu dans un navigateur
+
+GitHub sert les `.html` en `text/plain` (sécurité). Pour voir le rendu effectif :
+
+- **htmlpreview.github.io** :
+  https://htmlpreview.github.io/?https://github.com/chrisboulet/briefing-matinal/blob/main/docs/preview/sample-matin.html
+
+- **Localement** : cloner et `open docs/preview/sample-matin.html`
+
+## Régénérer
+
+```bash
+python -m scripts.build_briefing --moment matin --fixture tests/fixtures/sample_matin.json
+cp output/2026-04-19-matin.html docs/preview/sample-matin.html
+```

--- a/docs/preview/sample-matin.html
+++ b/docs/preview/sample-matin.html
@@ -1,0 +1,216 @@
+<!doctype html>
+<html lang="fr-CA">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Briefing matin 2026-04-19-matin</title>
+<style>
+/* Palette validée AA (≥4.5:1 texte normal, ≥3:1 large) — voir tests/test_render.py */
+:root {
+  --bg: #ffffff;
+  --fg: #1a1a1a;          /* 16.1:1 vs bg */
+  --muted: #595959;       /* 7.0:1 vs bg */
+  --link: #0a4ea2;        /* 8.4:1 vs bg */
+  --link-hov: #052b59;
+  --border: #e1e4e8;
+  --hero-bg: #f5f7fa;
+  --hero-accent: #0a4ea2;
+  --warn-bg: #fff3cd;
+  --warn-bd: #d4a92e;
+  --warn-fg: #5a4500;     /* 8.6:1 vs warn-bg */
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #121212;
+    --fg: #eaeaea;        /* 15.3:1 vs bg */
+    --muted: #a8a8a8;     /* 7.6:1 vs bg */
+    --link: #7cb6ff;      /* 8.5:1 vs bg */
+    --link-hov: #b3d4ff;
+    --border: #2a2a2a;
+    --hero-bg: #1c1c1c;
+    --hero-accent: #7cb6ff;
+    --warn-bg: #3a2f0a;
+    --warn-bd: #7a5e1a;
+    --warn-fg: #f0d878;   /* 9.2:1 vs warn-bg */
+  }
+}
+* { box-sizing: border-box; }
+html { font-size: 16px; -webkit-text-size-adjust: 100%; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1rem;
+  line-height: 1.5;
+  color: var(--fg);
+  background: var(--bg);
+}
+h1 {
+  font-size: 1.4rem;
+  line-height: 1.25;
+  margin: 0 0 1rem;
+  padding-bottom: .5rem;
+  border-bottom: 2px solid var(--fg);
+}
+h2 {
+  font-size: 1.1rem;
+  line-height: 1.3;
+  margin: 1.75rem 0 .75rem;
+  letter-spacing: .01em;
+}
+h3 {
+  font-size: 1rem;
+  line-height: 1.35;
+  margin: 0 0 .35rem;
+  font-weight: 600;
+}
+p { margin: .35rem 0; }
+a { color: var(--link); text-decoration: none; }
+a:hover, a:focus { color: var(--link-hov); text-decoration: underline; }
+article {
+  margin: 0 0 .9rem;
+  padding-bottom: .85rem;
+  border-bottom: 1px solid var(--border);
+}
+article:last-of-type { border-bottom: none; }
+.src { color: var(--muted); font-size: .85rem; margin-top: .25rem; }
+.hero {
+  background: var(--hero-bg);
+  border-left: 4px solid var(--hero-accent);
+  padding: .85rem 1rem;
+  border-radius: 4px;
+  margin-bottom: .75rem;
+  border-bottom: none;
+}
+.hero h3 { font-size: 1.05rem; }
+.warn {
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-bd);
+  color: var(--warn-fg);
+  padding: .6rem .85rem;
+  border-radius: 4px;
+  margin: 0 0 1rem;
+  font-size: .95rem;
+}
+.empty { color: var(--muted); font-style: italic; font-size: .9rem; }
+.meta {
+  color: var(--muted);
+  font-size: .75rem;
+  margin-top: 2.5rem;
+  padding-top: .75rem;
+  border-top: 1px dashed var(--border);
+  word-break: break-all;
+}
+</style>
+</head>
+<body>
+
+<h1>☀️ BRIEFING MATIN — 2026-04-19-matin</h1>
+
+
+<h2>⚡ EN 60 SECONDES</h2>
+<article class="hero">
+<h3><a href="https://x.com/AnthropicAI/status/1814000000000000002" rel="noopener noreferrer">Anthropic ships Claude 5.0 with extended context</a></h3>
+<p>Annonce officielle: 2M tokens context, latence réduite de 40%, prix stable.</p>
+<p class="src">via @AnthropicAI</p>
+</article>
+<article class="hero">
+<h3><a href="https://www.lapresse.ca/international/2026-04-19/trump-ai-export.php" rel="noopener noreferrer">Trump signs executive order on AI export controls</a></h3>
+<p>Décret signé hier soir restreignant l&#39;export de GPU H300+ vers 12 pays.</p>
+<p class="src">via lapresse.ca</p>
+</article>
+<article class="hero">
+<h3><a href="https://x.com/WholeMarsBlog/status/1814000000000000011" rel="noopener noreferrer">FSD v14 broader rollout begins this week</a></h3>
+<p>Tesla démarre rollout FSD v14 sur l&#39;ensemble du parc HW4 en NA.</p>
+<p class="src">via @WholeMarsBlog + 1 autre</p>
+</article>
+
+<h2>🤖 AI / Tech</h2>
+<article>
+<h3><a href="https://x.com/AnthropicAI/status/1814000000000000002" rel="noopener noreferrer">Anthropic ships Claude 5.0 with extended context</a></h3>
+<p>Annonce officielle: 2M tokens context, latence réduite de 40%, prix stable.</p>
+<p class="src">via @AnthropicAI</p>
+</article>
+<article>
+<h3><a href="https://x.com/karpathy/status/1814000000000000001" rel="noopener noreferrer">Karpathy on agentic coding patterns</a></h3>
+<p>Long thread sur les patterns émergents en agentic coding et leurs implications design.</p>
+<p class="src">via @karpathy</p>
+</article>
+<article>
+<h3><a href="https://x.com/OpenAI/status/1814000000000000003" rel="noopener noreferrer">OpenAI release: GPT-5 Multi tool</a></h3>
+<p>Nouveau mode multi-tool concurrent, approche similaire au flow Anthropic.</p>
+<p class="src">via @OpenAI</p>
+</article>
+<h2>🚗 Tesla</h2>
+<article>
+<h3><a href="https://x.com/WholeMarsBlog/status/1814000000000000011" rel="noopener noreferrer">FSD v14 broader rollout begins this week</a></h3>
+<p>Tesla démarre rollout FSD v14 sur l&#39;ensemble du parc HW4 en NA.</p>
+<p class="src">via @WholeMarsBlog + 1 autre</p>
+</article>
+<article>
+<h3><a href="https://x.com/cernbasher/status/1814000000000000010" rel="noopener noreferrer">Cybertruck production hits 250k unit milestone</a></h3>
+<p>Tesla franchit le cap des 250k Cybertrucks produits depuis le lancement.</p>
+<p class="src">via @cernbasher</p>
+</article>
+<h2>🚀 SpaceX</h2>
+<article>
+<h3><a href="https://x.com/SpaceX/status/1814000000000000021" rel="noopener noreferrer">Starlink V3 sats: 60 launched overnight</a></h3>
+<p>60 satellites V3 déployés cette nuit depuis Vandenberg, capacité +35%.</p>
+<p class="src">via @SpaceX</p>
+</article>
+<h2>🏥 Santé</h2>
+<article>
+<h3><a href="https://x.com/davidasinclair/status/1814000000000000030" rel="noopener noreferrer">Sinclair: NMN longitudinal trial 2-year results</a></h3>
+<p>Étude 2 ans sur 800 sujets, marqueurs biologiques améliorés sur 6 axes.</p>
+<p class="src">via @davidasinclair</p>
+</article>
+<article>
+<h3><a href="https://x.com/PeterAttiaMD/status/1814000000000000031" rel="noopener noreferrer">Attia: practical Zone 2 protocol update</a></h3>
+<p>Refonte du protocole Zone 2 basée sur 18 mois de données patients.</p>
+<p class="src">via @PeterAttiaMD</p>
+</article>
+<h2>🏛️ Politique</h2>
+<article>
+<h3><a href="https://www.lapresse.ca/international/2026-04-19/trump-ai-export.php" rel="noopener noreferrer">Trump signs executive order on AI export controls</a></h3>
+<p>Décret signé hier soir restreignant l&#39;export de GPU H300+ vers 12 pays.</p>
+<p class="src">via lapresse.ca</p>
+</article>
+<article>
+<h3><a href="https://www.journaldequebec.com/2026/04/19/budget-supplementaire-sante-2026" rel="noopener noreferrer">Legault annonce un budget supplémentaire en santé</a></h3>
+<p>Le gouvernement du Québec ajoute 2,3 G$ au budget santé pour l&#39;exercice en cours.</p>
+<p class="src">via journaldequebec.com</p>
+</article>
+<article>
+<h3><a href="https://www.lapresse.ca/international/2026-04-19/taiwan-survol.php" rel="noopener noreferrer">Tensions Taiwan: nouveau survol PLAAF</a></h3>
+<p>12 appareils PLAAF traversent la ligne médiane, plus haute fréquence depuis février.</p>
+<p class="src">via lapresse.ca</p>
+</article>
+<h2>💼 Business</h2>
+<article>
+<h3><a href="https://www.lesaffaires.com/entreprises/bce-distributel-2026" rel="noopener noreferrer">BCE rachète Distributel pour 1,8 G$</a></h3>
+<p>Acquisition annoncée hier soir, attend approbation CRTC.</p>
+<p class="src">via lesaffaires.com</p>
+</article>
+<article>
+<h3><a href="https://www.lesaffaires.com/marches/tsx-cloture-2026-04-18" rel="noopener noreferrer">TSX clôture en hausse de 1.2%, énergie en tête</a></h3>
+<p>Indice composé TSX +1.2% sur la séance, secteur énergie tire la performance.</p>
+<p class="src">via lesaffaires.com</p>
+</article>
+
+<h2>📌 À NE PAS MANQUER</h2>
+<article class="hero">
+<h3><a href="https://danielmiessler.com/blog/ai-alignment-2026" rel="noopener noreferrer">Daniel Miessler: AI alignment, the 2026 take</a></h3>
+<p>Essai sur l&#39;évolution du discours alignment depuis 2024.</p>
+<p class="src">via @DanielMiessler</p>
+</article>
+
+<p class="meta">
+briefing: 2026-04-19-matin ·
+config: 2fbf9c0 ·
+git: b0ca7f1 ·
+prompts: phase-1-no-llm ·
+généré: 2026-04-19T18:06:17+00:00
+</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Snapshot HTML rendu commit dans `docs/preview/` pour visualisation navigateur. `output/` reste gitignored (PRD design) ; cette PR ajoute uniquement un dossier `docs/preview/` dédié à la preview, jamais lu par le pipeline.

## Voir le rendu

Une fois mergé sur main :

🔗 **https://htmlpreview.github.io/?https://github.com/chrisboulet/briefing-matinal/blob/main/docs/preview/sample-matin.html**

(Le `htmlpreview.github.io` est nécessaire car GitHub sert les `.html` en `text/plain` pour des raisons de sécurité.)

Tu pourras valider :
- Rendu mobile (ouvrir l'URL sur ton iPhone)
- Mode dark/light auto (selon réglage système iOS)
- Lisibilité du contraste
- Espacement et typographie
- Sections hero (60 sec + à ne pas manquer)

## Test plan

- [ ] Ouvrir l'URL htmlpreview sur iPhone Safari (light mode + dark mode)
- [ ] Vérifier que tous les liens cliquables ouvrent bien (les URLs sont fictives mais doivent être actives)
- [ ] Confirmer que le rendu correspond à ce que tu veux pour la V1, ou flag les ajustements

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo