### PR TITLE
docs: mise à jour avancement projet (README, PLAN, CLAUDE)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,32 +2,143 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## État du projet
+## État du projet (avril 2026)
 
-Repo en amorçage : il ne contient pour l'instant que le PRD, un README, et la config sources (`sources/comptes.json`). Les répertoires `scripts/`, `templates/`, et `output/` annoncés dans le README n'existent pas encore — à créer au premier commit de code. Aucune toolchain Python n'est en place (pas de `pyproject.toml`, `requirements.txt`, ni tests). Le runtime cible est Python 3.11+.
+Pipeline V1 **assemblé et testé hors-ligne**. 4 phases du PLAN mergées sur `main` (PR #2, #3, #4, #6). 104 tests verts (`pytest -q`). Mode live xAI câblé mais **non encore validé contre l'API réelle** — requiert `XAI_API_KEY` côté hermes-agent.
 
-## Architecture cible
+| Phase | Statut | Livrables |
+|---|---|---|
+| 0 — Scaffolding | ✅ PR #2 | `pyproject.toml`, JSON schema, dirs |
+| 1 — Pipeline offline | ✅ PR #3 | `models`, `config`, `window`, `dedup`, `select`, `render`, `build_briefing`, fixture, 30 tests |
+| 2 — Template HTML prod | ✅ PR #4 | `templates/briefing.html` AA + dark/light, macro `_item.html`, 15 tests |
+| 3 — Intégration xAI | ✅ PR #6 | `xai_client`, `sourcing`, 4 prompts versionnés, `docs/xai-integration.md`, 59 tests |
+| 4 — Redirector Tailscale | ⏳ | service FastAPI + SQLite + tracking clics (parallélisable) |
+| 5 — Intégration hermes-agent | ⏳ | contrat stdout JSON figé, fallback NAS, runbook |
+| 6 — Tests étendus | ⏳ | DST edge cases, schema invalid, fixtures additionnelles |
+| 7 — Mise en service V1 | ⏳ | cron, premier envoi, monitoring 2 semaines |
 
-Pipeline quotidien exécuté par **Hermes Agent** (hôte externe à ce repo) via le skill `briefing-matinal`. Ce repo fournit la config + les scripts ; Hermes fournit le cron, les secrets, l'envoi Telegram, et le NAS.
+## Architecture actuelle
 
-Flux : `sources/comptes.json` → `scripts/build-briefing.py` (interroge xAI Grok `x_search` via `/v1/responses` + `web_search` Hermes en parallèle) → rendu via `templates/briefing.html` → fichier HTML standalone dans `output/YYYY-MM-DD.html` → Hermes envoie sur Telegram à 6h45 AM (America/Toronto), fallback NAS `/mnt/nas/commun/briefing-matinal/`.
+```
+briefing-matinal/
+├── PRD.md                          # Spec V2 (source de vérité)
+├── PLAN.md                         # Plan d'impl 7 phases (état d'avancement)
+├── docs/
+│   ├── xai-integration.md          # Référence opérationnelle xAI
+│   └── preview/sample-matin.html   # Snapshot HTML pour visualisation
+├── sources/
+│   ├── comptes.json                # Config runtime (15 comptes, 8 recherches, 6 sections)
+│   └── comptes.schema.json         # JSON Schema draft 2020-12
+├── prompts/                        # Templates Jinja LLM (versionnés via PROMPTS_VERSION)
+│   ├── system.txt
+│   ├── search_accounts.txt
+│   ├── search_theme.txt
+│   └── search_web.txt
+├── scripts/
+│   ├── models.py                   # Item, Briefing dataclasses
+│   ├── config.py                   # load_config + schema validation
+│   ├── window.py                   # Fenêtres matin/soir America/Toronto
+│   ├── dedup.py                    # canonical_url + title hash
+│   ├── select.py                   # quotas par section + 60s + dont_miss
+│   ├── render.py                   # Jinja2 + validation taille/CDN
+│   ├── xai_client.py               # httpx wrapper Responses API + retry
+│   ├── sourcing.py                 # orchestrateur appels xAI
+│   ├── fixture_loader.py           # mode offline (Phase 1)
+│   └── build_briefing.py           # CLI (switch fixture/live)
+├── templates/
+│   ├── briefing.html               # Layout Jinja AA-compliant
+│   └── partials/_item.html         # Macro item réutilisée
+├── tests/                          # 104 tests, 1.9s
+└── output/                         # Briefings générés (gitignored)
+```
 
-Les sections du briefing (AI/Tech, Tesla, SpaceX, Santé, Politique, Business + "En 60 secondes" et "À ne pas manquer") sont **data-driven** depuis `comptes.json` (clé `sections`, avec `max_items` par section). Toute modification de portée (comptes X, thèmes de recherche, sources web) passe par `comptes.json`, pas par le code.
+**Flux exécution** :
+
+`comptes.json` → `build_briefing.py --moment {matin|soir}` → soit `fixture_loader` (offline) soit `sourcing.source_briefing(XAIClient)` (live, appels parallèles `x_search`/`web_search` via Responses API) → filtres engagement + fenêtre → `dedup` → `select` (quotas + 60s + dont_miss) → `render` Jinja → HTML standalone dans `output/YYYY-MM-DD-{matin|soir}.html` + JSON stdout pour hermes-agent.
+
+## Commandes courantes
+
+```bash
+# Setup initial
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev,redirector]"
+
+# Tests + lint
+pytest -q                            # 104 tests, 1.9s
+ruff check .                         # All checks passed
+
+# Mode offline (fixture, gratuit)
+python -m scripts.build_briefing --moment matin \
+  --fixture tests/fixtures/sample_matin.json --dry-run
+
+# Mode live (requiert XAI_API_KEY)
+export XAI_API_KEY="xai-..."
+python -m scripts.build_briefing --moment matin --dry-run \
+  2>&1 | jq 'select(.event=="xai_call")'
+
+# Valider la config contre le schema
+python -c "import json, jsonschema; \
+  jsonschema.validate(json.load(open('sources/comptes.json')), \
+                      json.load(open('sources/comptes.schema.json'))); \
+  print('config OK')"
+
+# Régénérer le snapshot preview
+python -m scripts.build_briefing --moment matin \
+  --fixture tests/fixtures/sample_matin.json && \
+  cp output/2026-04-19-matin.html docs/preview/sample-matin.html
+```
+
+## Décisions V1 figées (voir PRD §Décisions V1)
+
+| # | Décision | Valeur |
+|---|---|---|
+| D1 | Cadence | 2x/jour, 6h45 + 17h30 America/Toronto |
+| D2 | Weekends | Identique semaine |
+| D3 | Budget lecture | Triage pur ≤ 5 min |
+| D4 | Politique | 1 section unifiée, 3 items max |
+| D5 | "À ne pas manquer" | Dans les 2 briefings |
+| D6 | Tracking | Short-links via redirector Tailscale (Phase 4) |
+| D7 | Langue | FR-QC structure, bilingue toléré sans traduction |
 
 ## Contraintes dures (non négociables)
 
-- **HTML standalone** : inline CSS uniquement, pas de CDN, pas de JS, pas de Google Fonts — polices système.
-- **Taille max 50 KB** (limite document Telegram).
-- **Mobile-first**, lisible en dark ET light.
-- **Latence < 3 min** pour la génération complète.
-- **Budget** ~0.10-0.15 $/jour (3-5 appels Grok max).
-- **Output gitignored** (`output/`), comme `.env` et `__pycache__/`.
+- **HTML standalone** : CSS inline (`<style>` unique), pas de CDN, pas de JS, polices système.
+- **Budget lisibilité ~50 KB** (réel actuel : 8.1 KB sur fixture pleine — 6× sous budget).
+- **Mobile-first**, contraste AA validé (≥7:1 partout en réalité).
+- **Auto dark/light** via `prefers-color-scheme`.
+- **Latence < 3 min** pour la génération complète (Phase 1 offline tourne en <1s).
+- **Budget xAI** ~0.22-0.30 $/jour (cf. `docs/xai-integration.md`).
+- **Output gitignored** (`output/`), comme `.env`, `*.db`, `.venv/`, caches.
+
+## Stack technique
+
+- **Python 3.11+** (alias `datetime.UTC`, `zoneinfo` stdlib)
+- **httpx** sync pour xAI Responses API
+- **jinja2** StrictUndefined + autoescape
+- **pydantic** pour validation (contrat I/O xAI)
+- **jsonschema** draft 2020-12 pour `comptes.json`
+- **fastapi + uvicorn** (Phase 4, redirector — déjà dans `[redirector]` extras)
+- **pytest + pytest-httpx** pour mocks API
+- **ruff** line-length 110, target py311 (configuré dans `pyproject.toml`)
+- **mypy** strict (configuré, pas encore lancé en CI)
+
+## Conventions
+
+- **Branches** : `claude/<phase-ou-feature>-<slug>` (ex. `claude/phase-3-xai`, `claude/docs-update`)
+- **PRs** : 1 PR par phase, squash-merge sur `main`
+- **Commits atomiques** au sein d'une PR (chore/feat/test/docs scopés)
+- **PROMPTS_VERSION** bumpée manuellement à chaque modification sémantique des prompts (injectée en footer HTML pour traçabilité)
+- **Config hash** SHA-256 de `comptes.json` injecté en footer HTML
+- **TODO(live):** marqueurs aux endroits où la doc xAI accessible ne fige pas la forme exacte — à valider au premier appel réel
 
 ## Non-goals explicites (voir PRD §Non-goals)
 
-Pas de posting X, pas de résumé vidéo YouTube, pas d'analyse de sentiment, pas de dashboard web, pas de multi-utilisateur. Ne pas fusionner avec le skill `bst-veille-hebdo` (veille pro, séparée).
+Pas de posting X, pas de résumé vidéo YouTube, pas d'analyse de sentiment, pas de dashboard web, pas de multi-utilisateur, pas de scraping HTML direct, pas d'alertes breaking news hors cycle (v2+), pas de traduction automatique. Ne pas fusionner avec le skill `bst-veille-hebdo`.
 
 ## Références
 
-- **PRD.md** — source de vérité pour les specs fonctionnelles (S1–S5), les contraintes techniques, et les critères de succès.
-- **sources/comptes.json** — config runtime (15 comptes X, 8 recherches thématiques, 3 sources web, 6 sections).
+- **PRD.md** — spec fonctionnelle V2, log des décisions V1, modes d'erreur, data model
+- **PLAN.md** — découpage 7 phases avec acceptance criteria
+- **docs/xai-integration.md** — référence opérationnelle xAI (endpoint, schema, retry, cost)
+- **sources/comptes.json** + **comptes.schema.json** — config runtime + validation
+- **docs/preview/sample-matin.html** — snapshot HTML rendu (visualisation via `htmlpreview.github.io`)

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,31 @@
 
 > Ce document détaille l'ordre et la structure d'implémentation de la V1 du pipeline, tel que spécifié dans `PRD.md` v2. Il est destiné à être relu avant chaque commit pour s'assurer qu'on reste dans le scope.
 
+## 🚦 État d'avancement (mis à jour 2026-04-19)
+
+| Phase | Statut | PR | SHA | Tests cumulés |
+|---|---|---|---|---|
+| 0 — Scaffolding | ✅ Mergé | [#2](https://github.com/chrisboulet/briefing-matinal/pull/2) | `de9b8e2` | 0 |
+| 1 — Pipeline offline | ✅ Mergé | [#3](https://github.com/chrisboulet/briefing-matinal/pull/3) | `05f8f2b` | 30 |
+| 2 — Template HTML prod | ✅ Mergé | [#4](https://github.com/chrisboulet/briefing-matinal/pull/4) | `b0ca7f1` | 45 |
+| 3 — Intégration xAI | ✅ Mergé | [#6](https://github.com/chrisboulet/briefing-matinal/pull/6) | `09e4c8a` | **104** |
+| 4 — Redirector Tailscale | ⏳ À faire | — | — | — |
+| 5 — Intégration hermes-agent | ⏳ À faire | — | — | — |
+| 6 — Tests étendus | ⏳ À faire | — | — | — |
+| 7 — Mise en service V1 | ⏳ À faire | — | — | — |
+
+**PR bonus** : [#5](https://github.com/chrisboulet/briefing-matinal/pull/5) — `docs/preview/sample-matin.html` (snapshot HTML pour visualisation navigateur).
+
+**Métriques actuelles** :
+- Tests : **104/104 verts** en 1.9s (`pytest -q`)
+- Lint : `ruff check .` → All checks passed
+- Briefing complet (17 items via fixture) : **8.1 KB** (6× sous budget 50 KB)
+- Mode live xAI **câblé mais non encore validé** sur API réelle (requiert `XAI_API_KEY`)
+
+**Prochaines étapes** : Phase 4 (redirector Tailscale) parallélisable avec Phase 5 (intégration hermes-agent). Phase 6 (tests étendus) au fil. Phase 7 (go-live) une fois mode live validé sur premier appel réel.
+
+---
+
 ## Contexte
 
 - **PRD source** : `PRD.md` (v2, commit `5a61521`)
@@ -41,7 +66,7 @@ Phases 1 et 2 peuvent se chevaucher si besoin. Phase 4 (redirector) est indépen
 
 ---
 
-## Phase 0 — Scaffolding
+## Phase 0 — Scaffolding ✅ Mergé via PR #2 (`de9b8e2`)
 
 **Objectif** : poser la structure du repo et les dépendances sans écrire de logique métier.
 
@@ -100,7 +125,7 @@ dev = [
 
 ---
 
-## Phase 1 — Pipeline offline avec fixtures
+## Phase 1 — Pipeline offline avec fixtures ✅ Mergé via PR #3 (`05f8f2b`)
 
 **Objectif** : produire un HTML de briefing complet à partir de fixtures JSON, sans aucun appel externe. **C'est le milestone le plus important de V1** — si ça marche ici, le reste est du branchement.
 
@@ -168,7 +193,7 @@ Comportement :
 
 ---
 
-## Phase 2 — Template HTML final
+## Phase 2 — Template HTML final ✅ Mergé via PR #4 (`b0ca7f1`)
 
 **Objectif** : transformer le placeholder Phase 1 en template production-ready : mobile-first, dark/light auto, accessibilité AA, budget lisibilité ~50 KB.
 
@@ -249,9 +274,16 @@ Dans `render.py`, après rendu Jinja, vérifier :
 
 ---
 
-## Phase 3 — Intégration xAI Grok Responses API
+## Phase 3 — Intégration xAI Grok Responses API ✅ Mergé via PR #6 (`09e4c8a`)
 
 **Objectif** : remplacer les fixtures par de vrais appels à l'API xAI. On garde le mode fixture pour les tests et le dev offline.
+
+**Notes post-merge** :
+- Délégation à 2 subagents pour qualité indépendante (reviewer + tests writer)
+- 3 CRITICAL + 7 MAJOR identifiés et fixés AVANT que les tests soient écrits (format:uri/date-time incompat strict json_schema, 429 retry off-by-one, backoff cap, tool_params validation, etc.)
+- 59 tests via mocks (pytest-httpx + StubClient) — aucun appel réel
+- `# TODO(live):` marqueurs aux endroits où la doc xAI accessible ne fige pas la forme exacte (extraction `output_text`, nom champ `tool_calls`, params `web_search`)
+- **À valider** sur premier appel réel avec `XAI_API_KEY`
 
 ### Livrables
 
@@ -336,7 +368,7 @@ Le CLI `build_briefing.py` détecte :
 
 ---
 
-## Phase 4 — Redirector + tracking (Tailscale)
+## Phase 4 — Redirector + tracking (Tailscale) ⏳ À faire
 
 **Objectif** : déployer le service FastAPI qui raccourcit les URLs et logge les clics. Indépendante des phases 1-3 — peut se faire en parallèle.
 
@@ -398,7 +430,7 @@ CREATE INDEX idx_clicks_at ON clicks(clicked_at);
 
 ---
 
-## Phase 5 — Intégration hermes-agent
+## Phase 5 — Intégration hermes-agent ⏳ À faire
 
 **Objectif** : brancher le pipeline sur le cron hermes-agent, valider le contrat stdout JSON, activer le fallback NAS.
 
@@ -454,9 +486,11 @@ CREATE INDEX idx_clicks_at ON clicks(clicked_at);
 
 ---
 
-## Phase 6 — Tests & validation
+## Phase 6 — Tests & validation ⏳ À faire (déjà 104 tests verts via Phases 1-3)
 
 **Objectif** : suite de tests verte, couvrant les cas tordus + un test end-to-end avec fixtures.
+
+> Mise à jour 2026-04-19 : la majorité des tests prévus pour cette phase ont déjà été écrits au fil des phases 1-3 (`test_dedup`, `test_select`, `test_window`, `test_render`, `test_e2e_offline`, `test_xai_client`, `test_sourcing`). Phase 6 se réduit à l'ajout des tests "pièges" résiduels (DST switch, schema invalid, fixtures additionnelles edge cases).
 
 ### Livrables
 
@@ -493,7 +527,7 @@ CREATE INDEX idx_clicks_at ON clicks(clicked_at);
 
 ---
 
-## Phase 7 — Mise en service V1
+## Phase 7 — Mise en service V1 ⏳ À faire
 
 **Objectif** : premier envoi réel à Chris, monitoring actif 2 semaines.
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,76 @@
 # Briefing Matinal
 
-Pipeline de briefing matinal personnalisé — veille multi-domaine livrée via Telegram.
+Pipeline de briefing matinal personnalisé — veille multi-domaine livrée 2×/jour sur Telegram via [hermes-agent](https://github.com/chrisboulet/hermes-agent).
+
+> **État** : V1 assemblée et testée hors-ligne. 4 phases sur 7 mergées (`main`). 104 tests verts. Mode live xAI câblé, **non encore validé** sur API réelle. Voir [`PLAN.md`](./PLAN.md) pour l'état d'avancement détaillé.
+
+## Aperçu
+
+- 🌅 **2 briefings/jour** : 6h45 (matin, fenêtre 17h30→6h30) + 17h30 (soir, fenêtre 6h30→17h15) America/Toronto
+- 📰 **Sources** : 15 comptes X surveillés + 8 recherches X thématiques + sites QC/CA (`journaldequebec.com`, `lesaffaires.com`, `lapresse.ca`)
+- 🤖 **Pipeline** : xAI Grok (`grok-4-1-fast-latest`) via Responses API + tools server-side `x_search` / `web_search`
+- 📱 **Format** : HTML standalone (~8 KB), inline CSS, mobile-first, dark/light auto, contraste AA
+- 🔗 **Tracking clics** : short-links via redirector Tailscale (Phase 4)
+- 💰 **Budget** : ~0.22-0.30 $/jour (~7-9 $/mois)
 
 ## Architecture
 
 ```
 briefing-matinal/
-├── PRD.md                      # Product Requirements Document
+├── PRD.md                       # Spec V2 (source de vérité)
+├── PLAN.md                      # Plan 7 phases + état d'avancement
+├── CLAUDE.md                    # Guide Claude Code
+├── docs/
+│   ├── xai-integration.md       # Référence opérationnelle xAI
+│   └── preview/                 # Snapshots HTML pour visualisation
 ├── sources/
-│   └── comptes.json            # Comptes X, recherches, sources web
-├── templates/                  # Templates HTML (à venir)
-├── scripts/                    # Scripts de build (à venir)
-└── output/                     # Briefings générés (gitignored)
+│   ├── comptes.json             # Config runtime
+│   └── comptes.schema.json      # Validation JSON Schema
+├── prompts/                     # Templates Jinja LLM versionnés
+├── scripts/                     # Modules pipeline + CLI
+├── templates/                   # Jinja HTML
+├── tests/                       # 104 tests (pytest, mocks)
+└── output/                      # Briefings générés (gitignored)
 ```
 
-## Usage
+## Voir un briefing rendu
 
-Ce repo est utilisé par Hermes Agent via le skill `briefing-matinal`. Le pipeline :
-1. Lit `sources/comptes.json` pour la config
-2. Interroge xAI Grok + web_search
-3. Compile le HTML via template
-4. Livre sur Telegram à 6h45 AM
+🔗 https://htmlpreview.github.io/?https://github.com/chrisboulet/briefing-matinal/blob/main/docs/preview/sample-matin.html
 
-## Modification
+(Régénérable via `python -m scripts.build_briefing --moment matin --fixture tests/fixtures/sample_matin.json && cp output/2026-04-19-matin.html docs/preview/sample-matin.html`)
 
-- Ajouter/retirer un compte X → éditer `sources/comptes.json`
-- Changer le template → éditer `templates/briefing.html`
-- Changer la logique de sourcing → éditer `scripts/build_briefing.py`
+## Lancer un briefing
+
+### Mode offline (fixture, gratuit)
+
+```bash
+python -m scripts.build_briefing --moment matin \
+  --fixture tests/fixtures/sample_matin.json --dry-run
+```
+
+Sortie JSON sur stdout : `{"status": "ok", "items_count": 17, "size_bytes": 8155, ...}`. HTML écrit dans `output/YYYY-MM-DD-matin.html` si `--dry-run` est omis.
+
+### Mode live (xAI, ~0.20 $/run)
+
+```bash
+export XAI_API_KEY="xai-..."
+python -m scripts.build_briefing --moment matin --dry-run \
+  2>&1 | jq 'select(.event=="xai_call")'
+```
+
+Voir [`docs/xai-integration.md`](./docs/xai-integration.md) pour la référence opérationnelle complète (endpoint, retry, coût, troubleshooting).
+
+## Modification de la portée
+
+| Quoi | Où |
+|---|---|
+| Ajouter/retirer un compte X | `sources/comptes.json` → `comptes_x` |
+| Ajouter/retirer une recherche thématique | `sources/comptes.json` → `recherches_thematiques` (lier à un `section_id`) |
+| Changer un seuil d'engagement | `sources/comptes.json` → `engagement_min` |
+| Ajouter une section | `sources/comptes.json` → `sections` (le template itère dynamiquement) |
+| Modifier le rendu HTML | `templates/briefing.html` + `templates/partials/_item.html` |
+| Modifier les prompts LLM | `prompts/*.txt` + bumper `PROMPTS_VERSION` dans `scripts/build_briefing.py` |
+| Modifier la logique de sourcing | `scripts/sourcing.py` |
 
 ## Développement
 
@@ -34,22 +78,37 @@ Prérequis : Python 3.11+, `pip` ≥ 23.
 
 ```bash
 # Setup
-python -m venv .venv
-source .venv/bin/activate
+python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev,redirector]"
 
-# Vérifier que tout est en place
-ruff check .
-pytest
+# Tests + lint
+pytest -q                     # 104 tests, 1.9s
+ruff check .                  # All checks passed
 
-# Valider la config contre le schema
+# Validation config
 python -c "import json, jsonschema; \
   jsonschema.validate(json.load(open('sources/comptes.json')), \
                       json.load(open('sources/comptes.schema.json'))); \
   print('config OK')"
-
-# Lancer un briefing en dry-run avec fixtures (à venir Phase 1)
-python -m scripts.build_briefing --moment matin --dry-run
 ```
 
-Voir [`PRD.md`](./PRD.md) pour les specs et [`PLAN.md`](./PLAN.md) pour l'ordre d'implémentation.
+## Contraintes dures
+
+- **HTML standalone** : CSS inline, pas de CDN, pas de JS, polices système
+- **Budget lisibilité 50 KB** (réel actuel 8.1 KB sur briefing plein)
+- **Mobile-first**, contraste AA validé (≥7:1)
+- **Latence < 3 min** par briefing
+- **Output gitignored**
+
+## Documentation
+
+| Fichier | Rôle |
+|---|---|
+| [`PRD.md`](./PRD.md) | Spec fonctionnelle V2, log des décisions, modes d'erreur, data model |
+| [`PLAN.md`](./PLAN.md) | 7 phases d'implémentation + état d'avancement |
+| [`CLAUDE.md`](./CLAUDE.md) | Guide pour Claude Code (architecture, commandes, conventions) |
+| [`docs/xai-integration.md`](./docs/xai-integration.md) | Référence opérationnelle xAI (endpoint, retry, coût) |
+
+## Licence
+
+Proprietary — Christian Boulet.


### PR DESCRIPTION
## Summary

Mise à jour des 3 fichiers de documentation principaux pour refléter l'état réel du projet après 4 phases mergées sur `main`. **Aucun changement de code** ; tests et lint inchangés.

### `README.md` — refonte complète

- Bandeau "État" en tête : V1 assemblée hors-ligne, mode live câblé non-validé
- Section "Aperçu" condensée : cadence, sources, pipeline, format, budget
- Architecture actuelle (au lieu de "à venir")
- Lien direct vers preview HTML rendu (htmlpreview.github.io)
- Section "Lancer un briefing" avec exemples mode offline + mode live
- Tableau "Modification de la portée" — où changer quoi
- Pointeurs vers les 4 docs (PRD, PLAN, CLAUDE, xai-integration)

### `PLAN.md` — tracking d'avancement

- Tableau d'avancement en tête (Phase, Statut, PR, SHA, tests cumulés)
- Métriques actuelles (104/104 tests verts en 1.9s, 8.1 KB briefing, ruff clean)
- Checkmarks ✅ sur chaque phase mergée avec PR + SHA
- Note Phase 6 réduite (la majorité des tests déjà écrits aux Phases 1-3)
- Note Phase 3 sur délégation subagents + marqueurs `TODO(live)`

### `CLAUDE.md` — guide pour Claude Code

- Remplacement complet de "Repo en amorçage" par état actuel
- Tableau des 7 phases avec statut
- Architecture actuelle complète (tous les fichiers)
- Commandes courantes (setup, tests, mode offline, mode live, validation, snapshot)
- Décisions V1 figées en tableau (D1-D7)
- Stack technique explicite (httpx, jinja2, pydantic, jsonschema, pytest-httpx, ruff, mypy)
- Conventions : branches `claude/<phase>-<slug>`, squash-merge, `PROMPTS_VERSION`, `TODO(live)`

## Test plan

- [x] `pytest -q` → 104/104 verts
- [x] `ruff check .` → All checks passed
- [x] Lecture humaine des 3 fichiers — cohérence avec l'état réel du repo confirmée

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo