### PR TITLE
fix(xai): parsing défensif shape réelle API (closes #15)

### DIFF
--- a/docs/xai-integration.md
+++ b/docs/xai-integration.md
@@ -81,32 +81,30 @@ Toute modification du modèle doit :
 
 ## Forme de la réponse
 
-> ⚠️ **Hypothèse documentée** : la doc complète de `docs.x.ai` n'a pas pu être fetchée depuis le sandbox de dev (403). Le parsing dans `xai_client.py` est défensif et tolère plusieurs formes ; les TODO dans le code marquent les points à valider sur premier appel réel.
-
-Forme **attendue** (alignée Responses API style OpenAI) :
+✅ **Confirmée au premier appel live** (issue #15, 2026-04-19) :
 
 ```json
 {
   "id": "resp_xxx",
-  "model": "grok-4-1-fast-2026-04-15",
+  "model": "grok-4-1-fast-non-reasoning",
   "output": [
-    {
-      "type": "message",
-      "role": "assistant",
-      "content": [
-        {"type": "output_text", "text": "{\"items\": [...], \"warnings\": [...]}"}
-      ]
-    }
+    {"type": "custom_tool_call", "name": "x_keyword_search", "call_id": "..."},
+    {"type": "custom_tool_call", "name": "x_semantic_search", "call_id": "..."},
+    {"type": "message", "role": "assistant",
+     "content": [{"type": "output_text", "text": "[{...}, {...}]"}]}
   ],
-  "usage": {
-    "input_tokens": 1234,
-    "output_tokens": 567,
-    "tool_calls": 3
-  }
+  "usage": {"input_tokens": 16000, "output_tokens": 800}
 }
 ```
 
-Le client extrait le `output_text` final et le parse comme JSON conforme à `ITEMS_SCHEMA`.
+**Points à connaître (vs hypothèses initiales)** :
+
+1. **`output_text` est souvent un array JSON nu** `[{...}, {...}]` au lieu du `{"items": [...], "warnings": [...]}` demandé par le prompt — `response_format: json_schema strict` n'est **pas** honoré de façon garantie. Le client wrappe défensivement : si `parsed` est une list, transformée en `{"items": parsed, "warnings": []}`.
+2. **Tool calls** : type réel = `"custom_tool_call"` (pas `"tool_call"` / `"tool_use"` / `"function_call"`). Le fallback de comptage accepte maintenant les 4 alias.
+3. **`usage.tool_calls` n'existe pas** dans la réponse — les tool calls sont à compter dans `output[]` via le fallback `_count_tool_calls_in_output()`.
+4. **Latence** observée : 6-10 s par appel (`grok-4-1-fast-non-reasoning`, ~16-20K tokens input par call).
+
+Le client extrait le `output_text` final (trois chemins tolérés, cf. `_extract_output_text`), parse le JSON, et normalise en `{items, warnings}`.
 
 ## Schéma des items retournés
 
@@ -205,10 +203,11 @@ Le coût d'un test live ≈ 0.22 $.
 
 Marqués `# TODO(live):` dans le code. Liste à jour :
 
-1. Forme exacte de la réponse Responses API (chemin du `output_text`)
-2. Format des `tool_params` pour `web_search` (nom exact de `allowed_domains`)
-3. Headers de rate limit (`X-RateLimit-*` ou autre)
-4. Comportement quand `response_format: json_schema` + tool fails — retourne-t-il quand même un JSON valide ?
+1. ✅ **Résolu (#15)** — `output_text` trouvé via `output[-1].content[-1].text`, et peut être une list ou un dict (parsing défensif).
+2. ✅ **Résolu (#15)** — `usage.tool_calls` n'existe pas ; fallback `_count_tool_calls_in_output()` compte `output[type="custom_tool_call"]`.
+3. Format des `tool_params` pour `web_search` (nom exact de `allowed_domains`) — à valider au premier call web réel.
+4. Headers de rate limit (`X-RateLimit-*` ou autre) — pas encore observés.
+5. Shape des items retournés par le LLM : est-ce que les champs `title/summary/canonical_url/section_id/...` sont respectés, ou est-ce que le modèle renvoie sa propre shape (`post_id/author/content/...`) malgré le schema strict ? — à surveiller sur le prochain test live, peut nécessiter un adaptateur dans `sourcing._to_item()`.
 
 ## Références
 

--- a/scripts/xai_client.py
+++ b/scripts/xai_client.py
@@ -383,12 +383,22 @@ class XAIClient:
         output_text = self._extract_output_text(raw)
         parsed = json.loads(output_text)
 
-        # Validation minimale de la structure (le strict json_schema côté API
-        # devrait déjà garantir, mais on re-vérifie en cas de fallback)
-        if "items" not in parsed or "warnings" not in parsed:
+        # Fix live (issue #15) : l'API retourne souvent un array JSON nu
+        # `[{...}, {...}]` au lieu de `{"items": [...], "warnings": [...]}`,
+        # malgré `response_format: json_schema strict`. On tolère les deux formes.
+        if isinstance(parsed, list):
+            parsed = {"items": parsed, "warnings": []}
+        elif not isinstance(parsed, dict):
             raise ValueError(
-                f"missing 'items' or 'warnings' in parsed output: {list(parsed.keys())}"
+                f"parsed output is neither list nor dict, got {type(parsed).__name__}"
             )
+
+        # Validation minimale de la structure (pour les cas pathologiques)
+        if "items" not in parsed:
+            raise ValueError(
+                f"missing 'items' in parsed output: {list(parsed.keys())}"
+            )
+        parsed.setdefault("warnings", [])
 
         usage_raw = raw.get("usage", {})
         # TODO(live): valider la clé exacte du compteur tool_calls.
@@ -415,7 +425,9 @@ class XAIClient:
         output = raw.get("output")
         if not isinstance(output, list):
             return 0
-        tool_call_types = ("tool_call", "tool_use", "function_call")
+        # Fix live (issue #15) : le type réel observé est `custom_tool_call`.
+        # On garde les autres pour compat future ou alias éventuels.
+        tool_call_types = ("custom_tool_call", "tool_call", "tool_use", "function_call")
         return sum(
             1 for entry in output
             if isinstance(entry, dict) and entry.get("type") in tool_call_types

--- a/tests/test_xai_client.py
+++ b/tests/test_xai_client.py
@@ -183,10 +183,13 @@ def test_usage_falls_back_to_num_tool_calls(
 def test_usage_falls_back_to_counting_tool_call_entries(
     client: XAIClient, httpx_mock: HTTPXMock
 ) -> None:
+    """Counts all 4 recognized tool-call entry types (custom_tool_call is the
+    actual type emitted by xAI per issue #15)."""
     inner = json.dumps({"items": [], "warnings": []})
     payload = {
         "model": "grok",
         "output": [
+            {"type": "custom_tool_call", "name": "x_keyword_search"},
             {"type": "tool_call", "name": "x_search"},
             {"type": "tool_use", "name": "x_search"},
             {"type": "function_call", "name": "x_search"},
@@ -196,7 +199,7 @@ def test_usage_falls_back_to_counting_tool_call_entries(
     }
     httpx_mock.add_response(url=XAI_URL, json=payload)
     resp = client.call("s", "u", tool="x_search")
-    assert resp.usage.tool_calls == 3
+    assert resp.usage.tool_calls == 4
 
 
 def test_cost_calculation_matches_constants() -> None:
@@ -260,7 +263,50 @@ def test_200_malformed_json_persists_raises_invalid_response(
 def test_200_valid_json_missing_items_key_raises_invalid(
     client: XAIClient, httpx_mock: HTTPXMock
 ) -> None:
-    inner = json.dumps({"foo": "bar"})  # missing items + warnings
+    inner = json.dumps({"foo": "bar"})  # missing items key → fatal
+    payload = {
+        "model": "grok",
+        "output_text": inner,
+        "usage": {"input_tokens": 0, "output_tokens": 0, "tool_calls": 0},
+    }
+    httpx_mock.add_response(url=XAI_URL, json=payload)
+    httpx_mock.add_response(url=XAI_URL, json=payload)
+
+    with pytest.raises(XAIInvalidResponse):
+        client.call("s", "u", tool="x_search")
+
+
+def test_200_bare_array_output_wraps_as_items(
+    client: XAIClient, httpx_mock: HTTPXMock
+) -> None:
+    """Issue #15: xAI Responses API may return a bare JSON array instead of
+    the documented {items, warnings} dict. Client must wrap it defensively."""
+    items = [
+        {
+            "title": "Sample", "summary": "s", "canonical_url": "https://x.com/a",
+            "source_type": "x_account", "source_handle": "@a",
+            "published_at": "2026-04-19T03:00:00Z", "score": 0.9,
+            "section_id": "ai-tech", "likes": 100, "reposts": 10,
+        }
+    ]
+    inner = json.dumps(items)  # bare array, not {"items": ..., "warnings": ...}
+    payload = {
+        "model": "grok",
+        "output_text": inner,
+        "usage": {"input_tokens": 50, "output_tokens": 20, "tool_calls": 1},
+    }
+    httpx_mock.add_response(url=XAI_URL, json=payload)
+
+    resp = client.call("s", "u", tool="x_search")
+    assert resp.parsed_output["items"] == items
+    assert resp.parsed_output["warnings"] == []
+
+
+def test_200_primitive_output_raises_invalid(
+    client: XAIClient, httpx_mock: HTTPXMock
+) -> None:
+    """Output that is neither list nor dict (e.g., a bare string) is pathological."""
+    inner = json.dumps("unexpected string output")
     payload = {
         "model": "grok",
         "output_text": inner,


### PR DESCRIPTION
Closes #15.

## Diagnostic (premier test live xAI)

10/10 appels API retournent 200 OK, mais crash au parsing :

```
unexpected error: AttributeError: 'list' object has no attribute 'keys'
```

Trois écarts entre hypothèses initiales et réponse effective :

| # | Hypothèse | Réalité |
|---|---|---|
| 1 | `output_text` = `{"items":[...],"warnings":[...]}` | **Array JSON nu** `[{...}, {...}]` |
| 2 | tool calls de type `tool_call` / `tool_use` / `function_call` | Type réel **`custom_tool_call`** |
| 3 | `usage.tool_calls` existe | N'existe pas → fallback obligatoire |

Le `response_format: json_schema strict` qu'on envoie **n'est pas honoré** de façon garantie.

## Fixes

### `scripts/xai_client.py`

- `_parse_response` : wrappe list → `{items: list, warnings: []}` ; `warnings` setdefault ; non-list/non-dict lève `ValueError` (→ retry → `XAIInvalidResponse`)
- `_count_tool_calls_in_output` : ajoute `custom_tool_call` en tête des 4 types

### `tests/test_xai_client.py` (+2 tests)

- `test_200_bare_array_output_wraps_as_items`
- `test_200_primitive_output_raises_invalid`
- Test existant `tool_call_entries` mis à jour (inclut `custom_tool_call`, compte 4 au lieu de 3)

### `docs/xai-integration.md`

- Shape réelle documentée (plus "Hypothèse" — "Confirmée au premier appel live")
- Points TODO(live) #1 et #2 marqués ✅ résolus
- Nouveau point #5 à surveiller : shape des **items** retournés (pas juste top-level) — le LLM peut ignorer notre schema et renvoyer ses propres fields (`post_id`, `author`, `content` observés dans l'issue). Si ça arrive, il faudra un adaptateur dans `sourcing._to_item()` — pour l'instant, le fix ne couvre que le top-level.

## Validation

- [x] `pytest -q` → **106/106 verts** en 1.8s (+2 vs 104)
- [x] `ruff check .` → All checks passed
- [x] Fixture dry-run inchangée (8.1 KB, 17 items)

## Métriques live observées (pour référence)

- ~0.04 $ pour 10 appels (soit ~0.004 $/appel — nettement moins cher qu'estimé)
- 6-10s par appel
- ~16-20K tokens input par call (gros — prompt ~8K + résultats tools ~8-12K)
- ~0.4-1.3K tokens output

## Prochaine étape

Re-tester live avec ce fix. Si nouveau crash sur shape items (`post_id` vs `title`), on ouvre un issue #16 et on ajoute un adaptateur dans `sourcing.py`.

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo