### PR TITLE
fix(sourcing): adapter shape native xAI + norm warnings (closes #17)

### DIFF
--- a/prompts/search_accounts.txt
+++ b/prompts/search_accounts.txt
@@ -37,4 +37,10 @@ If an item touches multiple, pick the most specific.
 # Quantity
 Return up to {{ max_items_total }} items total across all sections. Quality > quantity. Return fewer if appropriate.
 
+# REMINDER : output schema (see system prompt)
+- Exact shape: `{"items": [<item>, ...], "warnings": [...]}`
+- Each item uses EXACT field names: `title, summary, canonical_url, source_type, source_handle, published_at, score, section_id, likes, reposts`
+- Do NOT return `{post_id, author, content, engagement, link}` — transform to the schema
+- `source_type` for items from this call: `"x_account"`
+
 Return JSON only.

--- a/prompts/search_theme.txt
+++ b/prompts/search_theme.txt
@@ -24,4 +24,10 @@ Same scale as `search_accounts`. Calibrate down vs account-curated content (anon
 # Quantity
 Return up to {{ max_items }} items. Quality > quantity.
 
+# REMINDER : output schema (see system prompt)
+- Exact shape: `{"items": [<item>, ...], "warnings": [...]}`
+- Each item uses EXACT field names: `title, summary, canonical_url, source_type, source_handle, published_at, score, section_id, likes, reposts`
+- Do NOT return `{post_id, author, content, engagement, link}` — transform to the schema
+- For this call: `source_type="x_search"`, `section_id="{{ section_id }}"`
+
 Return JSON only.

--- a/prompts/search_web.txt
+++ b/prompts/search_web.txt
@@ -41,4 +41,11 @@ Wire stories often hit multiple outlets within minutes. If two articles cover th
 # Quantity
 Return up to {{ max_items_total }} items total. Filter aggressively for signal.
 
+# REMINDER : output schema (see system prompt)
+- Exact shape: `{"items": [<item>, ...], "warnings": [...]}`
+- Each item uses EXACT field names: `title, summary, canonical_url, source_type, source_handle, published_at, score, section_id, likes, reposts`
+- Do NOT return raw search results — transform to the schema
+- For this call: `source_type="web"`, `likes=0`, `reposts=0`
+- `source_handle` = the domain (e.g., `"journaldequebec.com"`)
+
 Return JSON only.

--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -1,7 +1,48 @@
-# OUTPUT
-- You MUST return ONLY a JSON object conforming to the provided `briefing_items` schema.
-- No prose, no markdown, no commentary outside the JSON.
-- All times you receive in user prompts are UTC (the caller has converted from America/Toronto).
+# OUTPUT (CRITICAL — read carefully)
+
+Return **ONLY** a JSON object with this EXACT shape:
+
+```json
+{
+  "items": [
+    {
+      "title":         "<short headline, language of origin>",
+      "summary":       "<1-2 lines in Quebec French, telegraphic>",
+      "canonical_url": "<full URL>",
+      "source_type":   "x_account" | "x_search" | "web",
+      "source_handle": "<@handle or domain>",
+      "published_at":  "<ISO 8601 UTC, e.g. 2026-04-19T03:15:00Z>",
+      "score":         <number 0.0 to 1.0>,
+      "section_id":    "<one of the section ids provided>",
+      "likes":         <integer, 0 if unknown>,
+      "reposts":       <integer, 0 if unknown>
+    }
+  ],
+  "warnings": ["<optional string messages>"]
+}
+```
+
+## DO NOT
+
+- **DO NOT** pass through raw tool results (`x_search` / `web_search` return `{post_id, author, content, engagement, link}` — those field names are WRONG).
+- **DO NOT** use alternative field names like `link`, `post_id`, `author`, `content`, `engagement`. Transform EVERY item into the schema above.
+- **DO NOT** add prose, markdown, commentary outside the JSON object.
+- **DO NOT** return a bare array — wrap in `{"items": [...], "warnings": [...]}`.
+
+## Required synthesis per item
+
+For each retained tool result:
+1. Map `link` → `canonical_url`
+2. Map `engagement.likes` → `likes`, `engagement.reposts` → `reposts`
+3. Derive `title` from the first sentence of the original post/article
+4. Write `summary` in Quebec French (1-2 lines, telegraphic, factual)
+5. Parse `source_handle` from author field (e.g., `"Financial Times (@FT)"` → `"@FT"`)
+6. Classify `section_id` (see section list in each prompt)
+7. Assign `score` based on the quality bar
+
+All times you receive in user prompts are UTC (the caller has converted from America/Toronto).
+
+---
 
 You are Christian's morning briefing sourcing agent.
 

--- a/scripts/sourcing.py
+++ b/scripts/sourcing.py
@@ -17,11 +17,12 @@ Conception :
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
@@ -30,6 +31,16 @@ from scripts.models import Item
 from scripts.xai_client import XAIClient, XAIError, XAIResponse, XAIUsage, iso_date
 
 logger = logging.getLogger(__name__)
+
+# "Financial Times (@FT)" → @FT ; retourne None si aucun @handle trouvé.
+_HANDLE_RE = re.compile(r"@[A-Za-z0-9_]{1,30}")
+
+# Mapping tool → source_type par défaut quand le LLM n'en fournit pas (issue #17).
+_SOURCE_TYPE_BY_TOOL: dict[str, Literal["x_account", "x_search", "web"]] = {
+    "x_search_accounts": "x_account",
+    "x_search_theme": "x_search",
+    "web_search": "web",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +162,9 @@ def source_briefing(
             window_start=window_start,
             window_end=window_end,
             valid_section_ids=valid_section_ids,
+            default_source_type="x_account",
+            # Pas de default_section_id pour accounts : le LLM doit classer
+            # chaque post selon son topic. Items sans section_id sont dropped.
         )
         items.extend(new_items)
         warnings.extend(new_warnings)
@@ -196,6 +210,8 @@ def source_briefing(
             window_start=window_start,
             window_end=window_end,
             valid_section_ids=valid_section_ids,
+            default_section_id=section_id,  # theme → section fixe
+            default_source_type="x_search",
         )
         items.extend(new_items)
         warnings.extend(new_warnings)
@@ -233,6 +249,9 @@ def source_briefing(
         window_start=window_start,
         window_end=window_end,
         valid_section_ids=valid_section_ids,
+        default_source_type="web",
+        # Web : le LLM classe, pas de default_section_id (articles couvrent
+        # politique, business, santé, etc.). Items sans section_id dropped.
     )
     items.extend(new_items)
     warnings.extend(new_warnings)
@@ -278,9 +297,14 @@ def _do_call(
     window_start: datetime,
     window_end: datetime,
     valid_section_ids: set[str],
+    default_section_id: str | None = None,
+    default_source_type: str | None = None,
 ) -> tuple[list[Item], list[str], XAIUsage]:
     """
     Effectue un appel xAI et convertit la réponse en items normalisés.
+
+    `default_*` servent au fallback dans `_to_item` quand le modèle passe
+    les résultats des tools en shape native (issue #17).
 
     Sur XAIError, retourne ([], [warning], usage_zéro) et logue — n'élève jamais.
     """
@@ -306,12 +330,19 @@ def _do_call(
         window_start=window_start,
         window_end=window_end,
         valid_section_ids=valid_section_ids,
+        default_section_id=default_section_id,
+        default_source_type=default_source_type,
     )
 
     # Warnings émis par le LLM lui-même (ex: "aucun post pour @X").
-    # TODO(live): valider que `parsed_output["warnings"]` est toujours présent
-    # quand le json_schema strict côté API est respecté.
-    llm_warnings = response.parsed_output.get("warnings", []) or []
+    # Normalisé en list[str] par xai_client._parse_response (issue #17).
+    llm_warnings_raw = response.parsed_output.get("warnings", [])
+    if isinstance(llm_warnings_raw, str):
+        llm_warnings = [llm_warnings_raw]
+    elif isinstance(llm_warnings_raw, list):
+        llm_warnings = [str(w) for w in llm_warnings_raw]
+    else:
+        llm_warnings = []
     all_warnings = [f"{prompt_label}: {w}" for w in llm_warnings] + parse_warnings
 
     return items, all_warnings, response.usage
@@ -324,6 +355,8 @@ def _items_from_response(
     window_start: datetime,
     window_end: datetime,
     valid_section_ids: set[str],
+    default_section_id: str | None = None,
+    default_source_type: str | None = None,
 ) -> tuple[list[Item], list[str]]:
     """
     Convertit `response.parsed_output["items"]` en liste d'Item validés.
@@ -332,6 +365,10 @@ def _items_from_response(
       - drop si published_at hors fenêtre (le LLM peut fudge)
       - drop si section_id non configuré
       - drop si la conversion lève une erreur (warning + skip)
+
+    `default_*` propagés vers `_to_item` pour combler les champs manquants
+    quand le modèle retourne la shape native xAI (issue #17).
+    `window_end` sert aussi de fallback `published_at` pour les items sans date.
     """
     raw_items = response.parsed_output.get("items", []) or []
     out: list[Item] = []
@@ -339,7 +376,12 @@ def _items_from_response(
 
     for raw in raw_items:
         try:
-            item = _to_item(raw)
+            item = _to_item(
+                raw,
+                default_section_id=default_section_id,
+                default_source_type=default_source_type,
+                fallback_published_at=window_end,
+            )
         except (KeyError, ValueError, TypeError) as exc:
             warnings.append(
                 f"{prompt_label}: skipped malformed item ({type(exc).__name__}: {exc})"
@@ -364,34 +406,98 @@ def _items_from_response(
     return out, warnings
 
 
-def _to_item(raw: dict[str, Any]) -> Item:
+def _to_item(
+    raw: dict[str, Any],
+    *,
+    default_section_id: str | None = None,
+    default_source_type: str | None = None,
+    fallback_published_at: datetime | None = None,
+) -> Item:
     """
     Construit un Item à partir du dict brut renvoyé par le LLM.
 
-    L'URL est canonisée (dedupe-friendly) et l'ID dérivé de cette URL.
-    Les champs absents du payload LLM (alt_sources, short_url, raw_excerpt)
-    reçoivent des valeurs par défaut neutres.
+    Accepte deux shapes (issue #17) :
+    1. Shape idéale (demandée par le prompt) : `{title, summary, canonical_url,
+       section_id, source_type, source_handle, published_at, score, likes, reposts}`
+    2. Shape native xAI (observée en pratique) : `{post_id, author, content,
+       engagement: {likes, reposts, views}, link}` — le modèle passe souvent
+       les résultats des tools tels quels.
+
+    Le contexte (`default_*`) permet de combler les champs que la shape native
+    ne fournit pas (section_id pour theme calls, source_type par tool,
+    published_at via window_end si absent).
     """
-    canonical = canonical_url(raw["canonical_url"])
-    published_at = datetime.fromisoformat(raw["published_at"].replace("Z", "+00:00"))
+    # URL : `canonical_url` (idéal) ou `link` / `url` (xAI native)
+    url = raw.get("canonical_url") or raw.get("link") or raw.get("url")
+    if not isinstance(url, str) or not url:
+        raise KeyError("no URL field (canonical_url/link/url) in item")
+    canonical = canonical_url(url)
+
+    # Engagement : flat (idéal) ou nested sous `engagement`
+    engagement = raw.get("engagement") if isinstance(raw.get("engagement"), dict) else {}
+    likes = int(raw.get("likes", engagement.get("likes", 0)) or 0)
+    reposts = int(raw.get("reposts", engagement.get("reposts", 0)) or 0)
+
+    # Title : explicit ou première ligne de `content`
+    title = raw.get("title")
+    if not isinstance(title, str) or not title.strip():
+        content = raw.get("content") or ""
+        title = content.split("\n", 1)[0][:200].strip() or "(sans titre)"
+
+    # Summary : explicit ou `content` (truncate pour budget rendu)
+    summary = raw.get("summary") or raw.get("content") or title
+    summary = str(summary)[:800]
+
+    # Source handle : explicit ou parse de `author` ("Name (@handle)")
+    source_handle = raw.get("source_handle")
+    if not isinstance(source_handle, str) or not source_handle.strip():
+        author = raw.get("author") or ""
+        match = _HANDLE_RE.search(author) if isinstance(author, str) else None
+        source_handle = match.group(0) if match else (author or "unknown")
+
+    # Source type : explicit ou default du call
+    source_type = raw.get("source_type") or default_source_type
+    if source_type not in ("x_account", "x_search", "web"):
+        raise KeyError(f"source_type invalid/missing (got {source_type!r})")
+
+    # Section_id : explicit ou default du call (theme calls seulement)
+    section_id = raw.get("section_id") or default_section_id
+    if not isinstance(section_id, str) or not section_id:
+        raise KeyError("section_id missing and no default_section_id provided")
+
+    # Published_at : ISO string ou fallback (window_end)
+    pub = raw.get("published_at") or raw.get("created_at")
+    if isinstance(pub, str) and pub:
+        published_at = datetime.fromisoformat(pub.replace("Z", "+00:00"))
+    elif fallback_published_at is not None:
+        published_at = fallback_published_at
+    else:
+        raise KeyError("published_at missing and no fallback provided")
+
+    # Score : 0.0-1.0 (default 0.5 si absent ou invalide)
+    try:
+        score = float(raw.get("score", 0.5))
+    except (TypeError, ValueError):
+        score = 0.5
+    score = max(0.0, min(1.0, score))
 
     return Item(
         id=item_id(canonical),
-        title=raw["title"],
-        summary=raw["summary"],
+        title=title,
+        summary=summary,
         canonical_url=canonical,
-        section_id=raw["section_id"],
-        source_type=raw["source_type"],
-        source_handle=raw["source_handle"],
+        section_id=section_id,
+        source_type=source_type,  # type: ignore[arg-type]
+        source_handle=source_handle,
         published_at=published_at,
-        score=float(raw["score"]),
+        score=score,
         short_url="",
         raw_excerpt="",
         alt_sources=(),
         is_reply=False,
         is_retweet=False,
-        likes=int(raw.get("likes", 0)),
-        reposts=int(raw.get("reposts", 0)),
+        likes=likes,
+        reposts=reposts,
     )
 
 

--- a/scripts/xai_client.py
+++ b/scripts/xai_client.py
@@ -398,7 +398,17 @@ class XAIClient:
             raise ValueError(
                 f"missing 'items' in parsed output: {list(parsed.keys())}"
             )
-        parsed.setdefault("warnings", [])
+
+        # Normalisation warnings (issue #17) : le LLM peut renvoyer une string
+        # unique ou autre chose. On force list[str] pour éviter l'itération
+        # char-par-char côté caller.
+        raw_warnings = parsed.get("warnings")
+        if isinstance(raw_warnings, str):
+            parsed["warnings"] = [raw_warnings]
+        elif isinstance(raw_warnings, list):
+            parsed["warnings"] = [str(w) for w in raw_warnings]
+        else:
+            parsed["warnings"] = []
 
         usage_raw = raw.get("usage", {})
         # TODO(live): valider la clé exacte du compteur tool_calls.

--- a/tests/test_sourcing.py
+++ b/tests/test_sourcing.py
@@ -555,3 +555,174 @@ def test_theme_user_prompt_mentions_theme_name(base_config, window) -> None:
         # The label is "search_theme_<theme>"; the theme name should appear in the rendered prompt.
         theme_name = call["prompt_label"].removeprefix("search_theme_")
         assert theme_name in call["user_prompt"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #17 : adapter _to_item pour shape native xAI
+# ---------------------------------------------------------------------------
+
+
+def test_to_item_accepts_xai_native_shape(base_config, window):
+    """xAI tool results have shape {post_id, author, content, engagement, link}
+    at the top level. The adapter must map them to our Item fields."""
+    from scripts.sourcing import _to_item
+
+    _, end = window
+    raw_native = {
+        "post_id": 2045842784033059114,
+        "author": "Financial Times (@FT)",
+        "content": "Recursive Superintelligence has been valued at $500B in latest round.",
+        "engagement": {"likes": 312, "reposts": 42, "views": 87491},
+        "link": "https://www.ft.com/content/a92bf04b-bbac-400f-9554-5b1c70957ad4",
+    }
+    item = _to_item(
+        raw_native,
+        default_section_id="ai-tech",
+        default_source_type="x_search",
+        fallback_published_at=end,
+    )
+    assert item.canonical_url == "https://www.ft.com/content/a92bf04b-bbac-400f-9554-5b1c70957ad4"
+    assert item.source_handle == "@FT"  # parsed from "Financial Times (@FT)"
+    assert item.likes == 312
+    assert item.reposts == 42
+    assert item.section_id == "ai-tech"
+    assert item.source_type == "x_search"
+    assert item.published_at == end  # fallback
+    assert "Recursive Superintelligence" in item.summary
+    assert item.score == 0.5  # default when missing
+
+
+def test_to_item_prefers_ideal_over_native_fields(base_config):
+    """When BOTH ideal and native fields are present, ideal wins (prompt worked)."""
+    from scripts.sourcing import _to_item
+
+    raw = {
+        # Ideal shape
+        "title": "Ideal title",
+        "summary": "Ideal summary",
+        "canonical_url": "https://ideal.example.com/a",
+        "source_handle": "@ideal",
+        "source_type": "x_account",
+        "published_at": "2026-04-19T03:00:00Z",
+        "score": 0.85,
+        "section_id": "ai-tech",
+        "likes": 100,
+        "reposts": 20,
+        # Also native fields (should be ignored)
+        "content": "Native content",
+        "link": "https://native.example.com/b",
+        "author": "Native Name (@native)",
+        "engagement": {"likes": 999, "reposts": 999},
+    }
+    item = _to_item(raw)
+    assert item.title == "Ideal title"
+    assert item.canonical_url == "https://ideal.example.com/a"
+    assert item.source_handle == "@ideal"
+    assert item.likes == 100
+
+
+def test_to_item_raises_on_missing_section_id_and_no_default(base_config):
+    from scripts.sourcing import _to_item
+
+    raw_native = {
+        "content": "A tweet",
+        "link": "https://x.com/a/status/1",
+        "author": "@a",
+    }
+    # No default_section_id → must raise
+    with pytest.raises(KeyError, match="section_id"):
+        _to_item(raw_native, default_source_type="x_account", fallback_published_at=datetime.now(UTC))
+
+
+def test_to_item_parses_bare_author_without_handle(base_config):
+    from scripts.sourcing import _to_item
+
+    raw = {
+        "content": "Post text",
+        "link": "https://x.com/a/status/1",
+        "author": "Some Org Without Handle",
+    }
+    item = _to_item(
+        raw, default_section_id="ai-tech", default_source_type="x_search",
+        fallback_published_at=datetime.now(UTC),
+    )
+    # No @ in author → falls back to the raw author string
+    assert item.source_handle == "Some Org Without Handle"
+
+
+def test_theme_call_injects_default_section_id(base_config, window):
+    """Theme calls pass default_section_id so native-shape items still classify."""
+    start, end = window
+    cfg = {**base_config, "comptes_x": [], "sources_web": [],
+           "recherches_thematiques": [
+               {"theme": "Tesla", "query": "tesla", "section_id": "tesla"}
+           ]}
+    native_item = {
+        "post_id": 1,
+        "author": "Tesla (@Tesla)",
+        "content": "Cybertruck production hits milestone",
+        "engagement": {"likes": 5000, "reposts": 800},
+        "link": "https://x.com/Tesla/status/1",
+    }
+    # Only one call expected (no accounts, no themes but Tesla, no web): actually
+    # 1 theme + 1 web = 2 calls. First is theme (Tesla), second is web.
+    client = StubClient([_ok_response(items=[native_item]), _ok_response()])
+
+    result = source_briefing(
+        client=client, config=cfg,
+        window_start=start, window_end=end,
+        prompts_dir=PROMPTS_DIR,
+    )
+    assert len(result.items) == 1
+    item = result.items[0]
+    assert item.section_id == "tesla"  # from default, LLM didn't provide
+    assert item.source_type == "x_search"
+    assert item.source_handle == "@Tesla"
+
+
+def test_account_call_drops_items_without_section_id(base_config, window):
+    """Account calls don't inject default_section_id — items without section_id
+    are dropped with a warning (can't classify across 15 handles deterministically)."""
+    start, end = window
+    cfg = {**base_config, "comptes_x": ["@karpathy"], "recherches_thematiques": [], "sources_web": []}
+    native_no_section = {
+        "post_id": 1,
+        "author": "@karpathy",
+        "content": "Some tweet",
+        "engagement": {"likes": 1000, "reposts": 100},
+        "link": "https://x.com/karpathy/status/1",
+    }
+    client = StubClient([_ok_response(items=[native_no_section]), _ok_response()])
+
+    result = source_briefing(
+        client=client, config=cfg,
+        window_start=start, window_end=end,
+        prompts_dir=PROMPTS_DIR,
+    )
+    assert result.items == []
+    assert any("section_id" in w for w in result.warnings)
+
+
+def test_warnings_string_does_not_iterate_char_by_char(base_config, window):
+    """Issue #17 bug 2 : if `parsed_output["warnings"]` is a string, it
+    must not be iterated char-by-char when building all_warnings."""
+    start, end = window
+    cfg = {**base_config, "comptes_x": ["@a"], "recherches_thematiques": [], "sources_web": []}
+    # Simulate xai_client normalization result: string wrapped in list.
+    resp_with_str_warning = XAIResponse(
+        parsed_output={"items": [], "warnings": ["Aucun résultat pour @a"]},
+        usage=XAIUsage(input_tokens=1, output_tokens=1, tool_calls=0),
+        duration_ms=10, model="stub",
+    )
+    client = StubClient([resp_with_str_warning, _ok_response()])
+
+    result = source_briefing(
+        client=client, config=cfg,
+        window_start=start, window_end=end,
+        prompts_dir=PROMPTS_DIR,
+    )
+    # Must see ONE warning with the full message, not 20+ single-char warnings.
+    matching = [w for w in result.warnings if "Aucun résultat pour @a" in w]
+    assert len(matching) == 1
+    # Also assert no single-char warnings
+    assert not any(len(w.split(": ", 1)[-1]) == 1 for w in result.warnings)

--- a/tests/test_xai_client.py
+++ b/tests/test_xai_client.py
@@ -575,3 +575,58 @@ def test_failed_5xx_log_status_server_error(
     logs = _parse_log_lines(captured.err)
     srv_logs = [r for r in logs if r.get("status") == "server_error"]
     assert len(srv_logs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Issue #17 : normalisation warnings (string → list[string])
+# ---------------------------------------------------------------------------
+
+
+def test_warnings_as_string_is_wrapped_in_list(
+    client: XAIClient, httpx_mock: HTTPXMock
+) -> None:
+    """Si le LLM renvoie `"warnings": "Aucun résultat"` (string au lieu de list),
+    _parse_response wrappe en list[string] pour éviter l'itération char-par-char
+    côté caller."""
+    inner = json.dumps({"items": [], "warnings": "Aucun résultat pour @X"})
+    payload = {
+        "model": "grok",
+        "output_text": inner,
+        "usage": {"input_tokens": 1, "output_tokens": 1, "tool_calls": 0},
+    }
+    httpx_mock.add_response(url=XAI_URL, json=payload)
+
+    resp = client.call("s", "u", tool="x_search")
+    warnings = resp.parsed_output["warnings"]
+    assert isinstance(warnings, list)
+    assert warnings == ["Aucun résultat pour @X"]
+
+
+def test_warnings_as_non_list_non_string_defaults_to_empty(
+    client: XAIClient, httpx_mock: HTTPXMock
+) -> None:
+    inner = json.dumps({"items": [], "warnings": {"nope": "dict"}})
+    payload = {
+        "model": "grok",
+        "output_text": inner,
+        "usage": {"input_tokens": 1, "output_tokens": 1, "tool_calls": 0},
+    }
+    httpx_mock.add_response(url=XAI_URL, json=payload)
+
+    resp = client.call("s", "u", tool="x_search")
+    assert resp.parsed_output["warnings"] == []
+
+
+def test_warnings_list_of_non_strings_coerced_to_str(
+    client: XAIClient, httpx_mock: HTTPXMock
+) -> None:
+    inner = json.dumps({"items": [], "warnings": ["ok", 42, None]})
+    payload = {
+        "model": "grok",
+        "output_text": inner,
+        "usage": {"input_tokens": 1, "output_tokens": 1, "tool_calls": 0},
+    }
+    httpx_mock.add_response(url=XAI_URL, json=payload)
+
+    resp = client.call("s", "u", tool="x_search")
+    assert resp.parsed_output["warnings"] == ["ok", "42", "None"]


### PR DESCRIPTION
Closes #17.

## Deux bugs diagnostiqués au deuxième test live

### Bug 1 — `items_count=0`, KeyError `canonical_url`

Le modèle xAI **passe les résultats des tools** (`x_keyword_search`, `web_search`) tels quels, avec leur shape native :

```json
{"post_id": 2045842784033059114, "author": "Financial Times (@FT)",
 "content": "Recursive Superintelligence has been valued...",
 "engagement": {"likes": 312, "reposts": 42, "views": 87491},
 "link": "https://www.ft.com/content/..."}
```

Notre `_to_item` cherchait `canonical_url`, `title`, `summary`, `section_id`, `source_handle`, `published_at`, `score` → KeyError → tous les items filtrés.

Cause : `response_format: json_schema strict` n'est pas honoré, le modèle ignore aussi notre prompt explicite sur le schéma de sortie.

### Bug 2 — Warnings itérés char-par-char

`parsed_output["warnings"]` retourné comme **string** au lieu de list → `[f"{label}: {w}" for w in warnings_str]` itère chaque caractère.

## Fixes

### `scripts/sourcing.py` — `_to_item` adaptatif

Accepte **2 shapes** avec mapping explicite de la native → la nôtre :

| Champ attendu | Source idéale | Source native (fallback) |
|---|---|---|
| `canonical_url` | `raw["canonical_url"]` | `raw["link"]` / `raw["url"]` |
| `source_handle` | `raw["source_handle"]` | regex `@\w+` dans `raw["author"]` |
| `likes` / `reposts` | `raw["likes"]` / `raw["reposts"]` | `raw["engagement"]["likes"/"reposts"]` |
| `title` | `raw["title"]` | 1ère ligne de `raw["content"]` (≤200 char) |
| `summary` | `raw["summary"]` | `raw["content"]` (≤800 char) |
| `score` | `raw["score"]` | `0.5` (default) |
| `section_id` | `raw["section_id"]` | `default_section_id` (context-injected) |
| `source_type` | `raw["source_type"]` | `default_source_type` (context-injected) |
| `published_at` | `raw["published_at"]` | `fallback_published_at` (= `window_end`) |

**Context injecté par type d'appel** :

| Call type | `default_source_type` | `default_section_id` |
|---|---|---|
| accounts (x_search) | `"x_account"` | ❌ aucun (items non classés dropped) |
| theme (x_search) | `"x_search"` | `theme_cfg["section_id"]` (Tesla → `tesla`) |
| web (web_search) | `"web"` | ❌ aucun (LLM doit classer) |

### `scripts/xai_client.py` — normalisation warnings

```python
raw_warnings = parsed.get("warnings")
if isinstance(raw_warnings, str):
    parsed["warnings"] = [raw_warnings]
elif isinstance(raw_warnings, list):
    parsed["warnings"] = [str(w) for w in raw_warnings]
else:
    parsed["warnings"] = []
```

Double défense côté `sourcing._do_call` aussi.

### Prompts `prompts/*.txt` renforcés

- `system.txt` — section OUTPUT réécrite avec schema exact dans un code block + **bloc "DO NOT"** très explicite listant tous les mauvais noms de champs (`post_id`, `link`, `content`, `engagement`, etc.) + tableau des mappings requis.
- Les 3 search prompts : reminder final avec shape exacte + `source_type` pré-déterminé pour ce call.

## Validations

- [x] `pytest -q` → **116/116 verts** (+10 vs 106)
- [x] `ruff check .` → All checks passed
- [x] `build_briefing --dry-run --fixture` → inchangé (8.1 KB, 17 items)

## Tests ajoutés (+10)

**test_sourcing.py** :
- `test_to_item_accepts_xai_native_shape` (avec le vrai exemple FT de l'issue)
- `test_to_item_prefers_ideal_over_native_fields`
- `test_to_item_raises_on_missing_section_id_and_no_default`
- `test_to_item_parses_bare_author_without_handle`
- `test_theme_call_injects_default_section_id` (end-to-end)
- `test_account_call_drops_items_without_section_id`
- `test_warnings_string_does_not_iterate_char_by_char`

**test_xai_client.py** :
- `test_warnings_as_string_is_wrapped_in_list`
- `test_warnings_as_non_list_non_string_defaults_to_empty`
- `test_warnings_list_of_non_strings_coerced_to_str`

## Stratégie

**Parsing défensif > prompt strict**. xAI n'honore ni `response_format: json_schema strict` ni nos prompts explicites sur la shape. La doctrine est désormais : prompts renforcés (2e ligne de défense) + code qui sait lire les 2 shapes possibles (1ère ligne de défense).

## Limite connue (follow-up éventuel)

Les items des **account calls** sans `section_id` seront toujours dropped — on ne peut pas classifier 15 handles spécifiques vers 6 sections de manière déterministe sans mapping explicite. Si ça pose problème en prod (trop d'items perdus), on ajoutera un `comptes_x_sections: {handle: section_id}` optionnel dans `comptes.json`.

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo