### PR TITLE
fix(template): ne plus rendre briefing.warnings dans le HTML (closes #19)

### DIFF
--- a/docs/preview/sample-matin.html
+++ b/docs/preview/sample-matin.html
@@ -16,9 +16,6 @@
   --border: #e1e4e8;
   --hero-bg: #f5f7fa;
   --hero-accent: #0a4ea2;
-  --warn-bg: #fff3cd;
-  --warn-bd: #d4a92e;
-  --warn-fg: #5a4500;     /* 8.6:1 vs warn-bg */
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -30,9 +27,6 @@
     --border: #2a2a2a;
     --hero-bg: #1c1c1c;
     --hero-accent: #7cb6ff;
-    --warn-bg: #3a2f0a;
-    --warn-bd: #7a5e1a;
-    --warn-fg: #f0d878;   /* 9.2:1 vs warn-bg */
   }
 }
 * { box-sizing: border-box; }
@@ -84,15 +78,6 @@ article:last-of-type { border-bottom: none; }
   border-bottom: none;
 }
 .hero h3 { font-size: 1.05rem; }
-.warn {
-  background: var(--warn-bg);
-  border: 1px solid var(--warn-bd);
-  color: var(--warn-fg);
-  padding: .6rem .85rem;
-  border-radius: 4px;
-  margin: 0 0 1rem;
-  font-size: .95rem;
-}
 .empty { color: var(--muted); font-style: italic; font-size: .9rem; }
 .meta {
   color: var(--muted);
@@ -208,9 +193,9 @@ article:last-of-type { border-bottom: none; }
 <p class="meta">
 briefing: 2026-04-19-matin ·
 config: 2fbf9c0 ·
-git: b0ca7f1 ·
-prompts: phase-1-no-llm ·
-généré: 2026-04-19T18:06:17+00:00
+git: 93af264 ·
+prompts: prompts-v1.0 ·
+généré: 2026-04-19T20:41:05+00:00
 </p>
 </body>
 </html>

--- a/templates/briefing.html
+++ b/templates/briefing.html
@@ -16,9 +16,6 @@
   --border: #e1e4e8;
   --hero-bg: #f5f7fa;
   --hero-accent: #0a4ea2;
-  --warn-bg: #fff3cd;
-  --warn-bd: #d4a92e;
-  --warn-fg: #5a4500;     /* 8.6:1 vs warn-bg */
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -30,9 +27,6 @@
     --border: #2a2a2a;
     --hero-bg: #1c1c1c;
     --hero-accent: #7cb6ff;
-    --warn-bg: #3a2f0a;
-    --warn-bd: #7a5e1a;
-    --warn-fg: #f0d878;   /* 9.2:1 vs warn-bg */
   }
 }
 * { box-sizing: border-box; }
@@ -84,15 +78,6 @@ article:last-of-type { border-bottom: none; }
   border-bottom: none;
 }
 .hero h3 { font-size: 1.05rem; }
-.warn {
-  background: var(--warn-bg);
-  border: 1px solid var(--warn-bd);
-  color: var(--warn-fg);
-  padding: .6rem .85rem;
-  border-radius: 4px;
-  margin: 0 0 1rem;
-  font-size: .95rem;
-}
 .empty { color: var(--muted); font-style: italic; font-size: .9rem; }
 .meta {
   color: var(--muted);
@@ -109,9 +94,9 @@ article:last-of-type { border-bottom: none; }
 
 <h1>{{ "☀️" if briefing.moment == "matin" else "🌙" }} BRIEFING {{ briefing.moment | upper }} — {{ briefing.briefing_id }}</h1>
 
-{% if briefing.warnings %}
-<p class="warn">⚠️ {{ briefing.warnings | join(" · ") }}</p>
-{% endif %}
+{# briefing.warnings est intentionnellement NON rendu (issue #19) : ce sont des
+   internaux de pipeline (items hors fenêtre, sections vides, appels xAI dégradés)
+   destinés à stderr et au JSON stdout pour hermes-agent, pas au lecteur final. #}
 
 <h2>⚡ EN 60 SECONDES</h2>
 {% for item in briefing.sixty_seconds %}

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -151,3 +151,24 @@ def test_render_warning_when_size_overflows(make_item, sections_cfg, minimal_bri
     html, warnings = render(minimal_briefing, sections_cfg)
     assert any("budget" in w for w in warnings)
     assert len(html.encode("utf-8")) > SIZE_BUDGET_BYTES
+
+
+def test_render_does_not_expose_pipeline_warnings(minimal_briefing, sections_cfg):
+    """Issue #19 : les warnings pipeline (items hors fenêtre, sections vides,
+    appels xAI dégradés) sont des internaux destinés à stderr et au JSON stdout
+    pour hermes-agent — ils ne doivent JAMAIS apparaître dans le HTML rendu."""
+    minimal_briefing.warnings = [
+        "search_accounts_1: skipped item outside window (published_at=2026-04-18T19:40:41+00:00)",
+        "search_theme_Tesla: skipped malformed item (KeyError: 'canonical_url')",
+        "section 'spacex' vide",
+    ]
+    html, _ = render(minimal_briefing, sections_cfg)
+
+    # Aucun warning ne doit fuiter dans le HTML (ni texte, ni emoji, ni classe CSS)
+    for warning_text in minimal_briefing.warnings:
+        assert warning_text not in html, f"warning leaked into HTML: {warning_text!r}"
+    assert "skipped item" not in html
+    assert "skipped malformed" not in html
+    assert "section 'spacex' vide" not in html
+    assert 'class="warn"' not in html
+    assert "--warn-bg" not in html  # variable CSS supprimée


### PR DESCRIPTION
Closes #19 (partie 1). Partie 2 flaggée pour issue séparée (voir "Hors scope" ci-dessous).

## Problème

Le template `templates/briefing.html` rendait **tous les warnings pipeline** en haut de la page :

```html
{% if briefing.warnings %}
<p class="warn">⚠️ {{ briefing.warnings | join(" · ") }}</p>
{% endif %}
```

Résultat visible par Chris :

> ⚠️ search_accounts_1: skipped item outside window (published_at=2026-04-18T19:40:41+00:00) · search_accounts_1: skipped item outside window · section 'spacex' vide · ...

Ces messages sont des **internaux** destinés à stderr (logs) + stdout (hermes-agent), **pas au lecteur final**.

## Changements

### `templates/briefing.html`

- Retrait du bloc `{% if briefing.warnings %} <p class="warn">…</p> {% endif %}` complet
- Remplacé par un **commentaire Jinja explicatif** pour dissuader toute réintroduction par réflexe
- Retrait de la classe CSS `.warn` (dead code après suppression du bloc)
- Retrait des **6 variables CSS dédiées** (`--warn-bg`, `--warn-bd`, `--warn-fg` en `:root` ET dans `@media prefers-color-scheme: dark`)

Effet de bord positif : **-379 B** sur le briefing complet (8155 → 7776 B, -4.6%).

### `tests/test_render.py` (+1 test)

Test de non-régression `test_render_does_not_expose_pipeline_warnings` qui injecte 3 warnings réalistes (item hors fenêtre, malformed, section vide) et vérifie qu'aucun ne fuite dans le HTML (texte, classe CSS, variable CSS). Prévient toute réintroduction.

### `docs/preview/sample-matin.html`

Régénéré depuis le nouveau template.

## Validations

- [x] `pytest -q` → **117/117 verts** (+1)
- [x] `ruff check .` → All checks passed
- [x] `grep -c 'warn\|⚠️' docs/preview/sample-matin.html` → **0**
- [x] `briefing.warnings` toujours exposé en stdout JSON (inchangé, hermes-agent peut les relayer si pertinent)
- [x] `briefing.warnings` toujours loggé en stderr via `xai_client._log_call` (inchangé)

## Hors scope — partie 2 à rouvrir en issue dédiée

L'issue #19 mentionne aussi : *"Un item Santé a un mauvais titre — le modèle xAI interprète mal le contenu. Problème de prompt ou de mapping, à investiguer."*

Sans l'exemple concret (titre rendu + payload raw retourné par xAI), tout fix serait spéculatif. Hypothèses possibles :

1. `_to_item` dérive `title` du premier `"\n"` de `content` — mal coupé si le post X commence par un caractère ambigu
2. Le mapping `author → source_handle` prend la regex `@\w+` mais échoue sur des comptes santé sans handle X évident (ex: `@PeterAttiaMD` vs `"Dr. Peter Attia"`)
3. Le LLM lui-même résume mal en français les contenus anglophones santé

**Action recommandée** : ouvrir **issue #20** avec :
- Capture/extrait de l'item fautif (title + summary + source_handle rendus)
- Payload raw xAI correspondant (si disponible via logs stderr)

Je peux ensuite investiguer avec données à l'appui plutôt qu'en aveugle.

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo