### PR TITLE
fix(sourcing): dérivation de titre propre depuis content brut (issue #19 partie 2)

### DIFF
--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -34,11 +34,21 @@ Return **ONLY** a JSON object with this EXACT shape:
 For each retained tool result:
 1. Map `link` → `canonical_url`
 2. Map `engagement.likes` → `likes`, `engagement.reposts` → `reposts`
-3. Derive `title` from the first sentence of the original post/article
+3. **Synthesize a clean `title`** (3-12 words) — do NOT copy the first line of `content` verbatim. The title should be a headline, not a tweet excerpt. Strip thread markers (`🧵`, `1/12`), leading attributions, and trailing URLs.
 4. Write `summary` in Quebec French (1-2 lines, telegraphic, factual)
 5. Parse `source_handle` from author field (e.g., `"Financial Times (@FT)"` → `"@FT"`)
 6. Classify `section_id` (see section list in each prompt)
 7. Assign `score` based on the quality bar
+
+### Title examples (critical — follow this pattern)
+
+| Raw `content` | ❌ BAD title (copy-paste) | ✅ GOOD title (synthesized) |
+|---|---|---|
+| `🧵 1/12 New longitudinal study on NMN shows significant biomarker improvements over 2 years...` | `🧵 1/12 New longitudinal study on NMN shows significant biomarker improvements over 2 years...` | `NMN longitudinal study: 2-year biomarker gains` |
+| `Peter Attia: Here's what the latest research on Zone 2 training actually reveals. https://t.co/xyz` | `Peter Attia: Here's what the latest research on Zone 2 training actually reveals. https://t.co/xyz` | `Attia: new findings on Zone 2 training` |
+| `BREAKING: Tesla announces FSD v14 broader rollout next week.` | `BREAKING: Tesla announces FSD v14 broader rollout next week.` | `Tesla FSD v14: broader rollout next week` |
+
+Preserve the **original language** of the title (English stays English, French stays French). Only the `summary` is translated to Quebec French.
 
 All times you receive in user prompts are UTC (the caller has converted from America/Toronto).
 

--- a/scripts/sourcing.py
+++ b/scripts/sourcing.py
@@ -35,6 +35,62 @@ logger = logging.getLogger(__name__)
 # "Financial Times (@FT)" → @FT ; retourne None si aucun @handle trouvé.
 _HANDLE_RE = re.compile(r"@[A-Za-z0-9_]{1,30}")
 
+# Nettoyage des titres dérivés de `content` quand le LLM ne synthétise pas
+# (issue #19 partie 2). Deux familles de bruit observées sur les posts X :
+# 1. Marqueurs de thread en tête : "🧵", "1/", "1/12", "1." etc.
+# 2. URLs t.co/... laissées en queue.
+_LEADING_NOISE_RE = re.compile(r"^\s*(?:🧵|\d+/(?:\d+)?|\d+[.)])\s*")
+_TRAILING_URL_RE = re.compile(r"\s+https?://\S+\s*$")
+
+# Cap titre : 160 chars = bonne densité mobile sans coupure brutale.
+_TITLE_MAX_CHARS = 160
+_TITLE_MIN_SENTENCE_CHARS = 40  # évite les phrases trop courtes
+_TITLE_MAX_SENTENCE_CHARS = 160
+_SENTENCE_BOUNDARY_RE = re.compile(
+    rf"^(.{{{_TITLE_MIN_SENTENCE_CHARS},{_TITLE_MAX_SENTENCE_CHARS}}}[.!?…])"
+)
+
+
+def _derive_title_from_content(content: str) -> str:
+    """
+    Dérive un titre lisible depuis le `content` brut d'un post X.
+
+    Fallback utilisé quand le LLM passe les résultats de tool en shape native
+    et ne synthétise pas de `title` (issue #19 partie 2). Les posts X santé/tech
+    commencent souvent par du bruit ("🧵 1/12 ...") et finissent par une URL
+    t.co — les deux sont retirés avant troncature.
+
+    Ordre de traitement :
+      1. Strip leading noise (jusqu'à 2 passes : "🧵 1/12 ..." → "...")
+      2. Garde première ligne uniquement
+      3. Strip trailing URL
+      4. Si > 160 chars : coupe à la frontière de phrase (.!?…) entre 40-160
+      5. Fallback hard truncation à 160 chars ou "(sans titre)" si vide
+    """
+    text = (content or "").strip()
+    if not text:
+        return "(sans titre)"
+
+    # 1. Strip leading noise (2 passes : "🧵 1/12" nécessite 2 itérations)
+    for _ in range(2):
+        stripped = _LEADING_NOISE_RE.sub("", text).strip()
+        if stripped == text:
+            break
+        text = stripped
+
+    # 2. Première ligne seulement (évite les threads multilignes)
+    text = text.split("\n", 1)[0].strip()
+
+    # 3. Strip trailing URL (t.co/... typique)
+    text = _TRAILING_URL_RE.sub("", text).strip()
+
+    # 4+5. Troncature : privilégier frontière de phrase, sinon hard cap
+    if len(text) > _TITLE_MAX_CHARS:
+        match = _SENTENCE_BOUNDARY_RE.match(text)
+        text = match.group(1) if match else text[:_TITLE_MAX_CHARS].rstrip()
+
+    return text or "(sans titre)"
+
 # Mapping tool → source_type par défaut quand le LLM n'en fournit pas (issue #17).
 _SOURCE_TYPE_BY_TOOL: dict[str, Literal["x_account", "x_search", "web"]] = {
     "x_search_accounts": "x_account",
@@ -438,11 +494,12 @@ def _to_item(
     likes = int(raw.get("likes", engagement.get("likes", 0)) or 0)
     reposts = int(raw.get("reposts", engagement.get("reposts", 0)) or 0)
 
-    # Title : explicit ou première ligne de `content`
+    # Title : explicit si fourni par le LLM, sinon dérivé du content brut
+    # via un helper qui nettoie le bruit courant (thread markers, trailing URLs).
+    # Voir _derive_title_from_content pour le détail (issue #19 partie 2).
     title = raw.get("title")
     if not isinstance(title, str) or not title.strip():
-        content = raw.get("content") or ""
-        title = content.split("\n", 1)[0][:200].strip() or "(sans titre)"
+        title = _derive_title_from_content(raw.get("content") or "")
 
     # Summary : explicit ou `content` (truncate pour budget rendu)
     summary = raw.get("summary") or raw.get("content") or title

--- a/tests/test_sourcing.py
+++ b/tests/test_sourcing.py
@@ -726,3 +726,118 @@ def test_warnings_string_does_not_iterate_char_by_char(base_config, window):
     assert len(matching) == 1
     # Also assert no single-char warnings
     assert not any(len(w.split(": ", 1)[-1]) == 1 for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Issue #19 partie 2 : dérivation de titre propre depuis content brut
+# ---------------------------------------------------------------------------
+
+
+def test_derive_title_strips_thread_marker_emoji():
+    from scripts.sourcing import _derive_title_from_content
+
+    title = _derive_title_from_content("🧵 Some interesting new research came out.")
+    assert title == "Some interesting new research came out."
+
+
+def test_derive_title_strips_thread_numbering():
+    from scripts.sourcing import _derive_title_from_content
+
+    title = _derive_title_from_content("1/12 New longitudinal study on NMN shows gains.")
+    assert title == "New longitudinal study on NMN shows gains."
+
+
+def test_derive_title_strips_combined_thread_markers():
+    """Cas réel santé observé : '🧵 1/12 ...' combine les deux."""
+    from scripts.sourcing import _derive_title_from_content
+
+    title = _derive_title_from_content(
+        "🧵 1/12 New longitudinal study on NMN shows significant biomarker improvements."
+    )
+    assert title.startswith("New longitudinal study on NMN")
+    assert "🧵" not in title
+    assert "1/12" not in title
+
+
+def test_derive_title_strips_trailing_url():
+    from scripts.sourcing import _derive_title_from_content
+
+    title = _derive_title_from_content("Interesting finding worth reading. https://t.co/abc123")
+    assert title == "Interesting finding worth reading."
+    assert "t.co" not in title
+    assert "http" not in title
+
+
+def test_derive_title_keeps_first_line_only_for_threads():
+    from scripts.sourcing import _derive_title_from_content
+
+    title = _derive_title_from_content(
+        "Main headline here.\n\nDetails and second paragraph here."
+    )
+    assert title == "Main headline here."
+
+
+def test_derive_title_truncates_at_sentence_boundary_when_long():
+    from scripts.sourcing import _derive_title_from_content
+
+    # Content > 160 chars : la 1re phrase seule fait ~120 char, la suite pousse
+    # le total au-delà → doit couper à la frontière de phrase.
+    content = (
+        "This is a reasonably long informative first sentence that stands on its own. "
+        "Additional commentary and detail and discussion follow in the second sentence and beyond, "
+        "and those details should not end up inside the title text."
+    )
+    assert len(content) > 160, "test fixture must exceed TITLE_MAX_CHARS"
+    title = _derive_title_from_content(content)
+    # Doit couper après la 1re phrase (frontière .), pas à 160 char brutaux
+    assert title == "This is a reasonably long informative first sentence that stands on its own."
+    assert title.endswith(".")
+
+
+def test_derive_title_hard_truncates_when_no_sentence_boundary():
+    from scripts.sourcing import _derive_title_from_content
+
+    content = "x" * 300
+    title = _derive_title_from_content(content)
+    assert len(title) <= 160
+    assert title == "x" * 160
+
+
+def test_derive_title_returns_placeholder_for_empty():
+    from scripts.sourcing import _derive_title_from_content
+
+    assert _derive_title_from_content("") == "(sans titre)"
+    assert _derive_title_from_content("   ") == "(sans titre)"
+    assert _derive_title_from_content("🧵") == "(sans titre)"
+
+
+def test_derive_title_preserves_short_content_as_is():
+    from scripts.sourcing import _derive_title_from_content
+
+    assert _derive_title_from_content("Short tweet.") == "Short tweet."
+
+
+def test_to_item_uses_derived_title_when_llm_omits(window):
+    """End-to-end : _to_item dérive le titre propre quand le LLM ne fournit
+    pas `title` et passe seulement content native xAI."""
+    from scripts.sourcing import _to_item
+
+    _, end = window
+    raw = {
+        "post_id": 1,
+        "author": "Peter Attia (@PeterAttiaMD)",
+        "content": "🧵 1/8 Here is what the latest research on fasting actually reveals. https://t.co/xyz",
+        "engagement": {"likes": 500, "reposts": 80},
+        "link": "https://x.com/PeterAttiaMD/status/1",
+    }
+    item = _to_item(
+        raw,
+        default_section_id="sante",
+        default_source_type="x_search",
+        fallback_published_at=end,
+    )
+    # Le titre est nettoyé : pas de 🧵, pas de 1/8, pas de t.co trailing
+    assert "🧵" not in item.title
+    assert "1/8" not in item.title
+    assert "t.co" not in item.title
+    assert item.title.startswith("Here is what the latest research")


### PR DESCRIPTION
Traite la partie 2 de l'issue #19 laissée en suspens par la PR #20 (*"Un item Santé a un mauvais titre — le modèle xAI interprète mal le contenu"*).

## Diagnostic (sans repro concret, raisonnement)

Depuis la PR #18, le modèle xAI passe les résultats des tools en shape native (`{post_id, author, content, engagement, link}`) sans synthétiser. Notre `_to_item` fallback utilisait :

```python
title = content.split("\n", 1)[0][:200].strip()
```

Pour un post X santé typique `"🧵 1/12 New longitudinal study on NMN shows gains... https://t.co/xyz"`, le titre résultant contient le bruit thread + URL. Ça explique raisonnablement les titres dégradés observés, particulièrement sur comptes santé (Attia, Sinclair, Huberman) qui utilisent fréquemment ce format.

## Fix : 2 volets complémentaires

### 1. Helper `_derive_title_from_content` (défense immédiate)

Fonction pure, module-level, testable. Pipeline de nettoyage :

| Étape | Exemple avant → après |
|---|---|
| Strip leading noise (2 passes) | `"🧵 1/12 Some text"` → `"Some text"` |
| 1ère ligne seulement | `"Title\nBody..."` → `"Title"` |
| Strip trailing URL | `"Interesting. https://t.co/abc"` → `"Interesting."` |
| Sentence-boundary truncation si >160 chars | coupe à `.` `!` `?` `…` dans [40-160] |
| Hard cap 160 chars sinon | |
| `"(sans titre)"` si vide | |

Cap passé de 200 → 160 chars (meilleure densité mobile).

### 2. Prompt `system.txt` renforcé (défense long terme)

- Étape 3 de "Required synthesis" réécrite : "Synthesize a clean title (3-12 words) — do NOT copy the first line of content verbatim"
- **Table d'exemples BAD vs GOOD** (3 cas : thread santé, podcast Attia, breaking Tesla) pour guider le modèle
- Rappel : titre dans la langue d'origine, seul `summary` en FR-QC

Les deux approches sont **complémentaires** : le helper garantit un résultat propre même si le LLM passe en shape native ; le prompt pousse le LLM à synthétiser de meilleurs titres à la source.

## Tests (+10)

Couvre les patterns les plus probables :
- Strip `🧵` seul, `"1/12"` seul, combos `"🧵 1/12"`
- Strip trailing URL `t.co/...`
- Threads multilignes → 1ère ligne seulement
- Sentence-boundary truncation > 160 chars
- Hard truncation sans ponctuation (content de `"x" * 300`)
- Placeholders `"(sans titre)"` pour vide / whitespace / `"🧵"` seul
- Content court gardé intact
- End-to-end via `_to_item` avec payload natif Peter Attia

## Validations

- [x] `pytest -q` → **127/127 verts** (+10)
- [x] `ruff check .` → All checks passed

## Limite reconnue

Sans l'exemple concret du titre fautif + payload raw xAI correspondant, je ne peux pas garantir que le cas précis observé est couvert à 100 %. Les 10 tests couvrent les patterns les plus probables sur posts X santé (threads Attia/Sinclair/Huberman). Si un cas résiduel apparaît après cette PR, ouvrir un issue avec le payload raw capturé via stderr.

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo