### PR TITLE
feat: retire la section 'EN 60 SECONDES' (closes #22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ briefing-matinal/
 │   ├── config.py                   # load_config + schema validation
 │   ├── window.py                   # Fenêtres matin/soir America/Toronto
 │   ├── dedup.py                    # canonical_url + title hash
-│   ├── select.py                   # quotas par section + 60s + dont_miss
+│   ├── select.py                   # quotas par section + dont_miss
 │   ├── render.py                   # Jinja2 + validation taille/CDN
 │   ├── xai_client.py               # httpx wrapper Responses API + retry
 │   ├── sourcing.py                 # orchestrateur appels xAI
@@ -54,7 +54,7 @@ briefing-matinal/
 
 **Flux exécution** :
 
-`comptes.json` → `build_briefing.py --moment {matin|soir}` → soit `fixture_loader` (offline) soit `sourcing.source_briefing(XAIClient)` (live, appels parallèles `x_search`/`web_search` via Responses API) → filtres engagement + fenêtre → `dedup` → `select` (quotas + 60s + dont_miss) → `render` Jinja → HTML standalone dans `output/YYYY-MM-DD-{matin|soir}.html` + JSON stdout pour hermes-agent.
+`comptes.json` → `build_briefing.py --moment {matin|soir}` → soit `fixture_loader` (offline) soit `sourcing.source_briefing(XAIClient)` (live, appels parallèles `x_search`/`web_search` via Responses API) → filtres engagement + fenêtre → `dedup` → `select` (quotas par section + dont_miss) → `render` Jinja → HTML standalone dans `output/YYYY-MM-DD-{matin|soir}.html` + JSON stdout pour hermes-agent.
 
 ## Commandes courantes
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -135,7 +135,7 @@ dev = [
 | `scripts/config.py` | Chargement + validation de `comptes.json` contre le schema |
 | `scripts/window.py` | Calcul des fenêtres temporelles matin/soir (pure function) |
 | `scripts/dedup.py` | Logique de dédup (URL canonique + hash titre) |
-| `scripts/select.py` | Sélection `max_items` par section + sections "hero" (60s, dont_miss) |
+| `scripts/select.py` | Sélection `max_items` par section + sélection "À ne pas manquer" |
 | `scripts/render.py` | Wrapper Jinja2 autour de `templates/briefing.html` |
 | `scripts/build_briefing.py` | Entrée CLI avec `argparse`, orchestrateur |
 | `tests/fixtures/x_search_sample.json` | ~30 posts X fake répartis sur tous les comptes/thèmes |
@@ -157,7 +157,7 @@ Comportement :
 2. Charge les fixtures comme si c'étaient des retours xAI
 3. Applique filtres qualité (engagement min, exclure replies, etc.)
 4. Dédup
-5. Sélectionne `max_items` par section + 3 items "60 secondes" + 1 "à ne pas manquer"
+5. Sélectionne `max_items` par section + 1 item "À ne pas manquer"
 6. Rend le HTML via Jinja2 (template placeholder OK à ce stade)
 7. Écrit `output/YYYY-MM-DD-matin.html`
 8. Print JSON stdout : `{"status": "ok", "path": "...", "briefing_id": "...", "items_count": N}`
@@ -202,7 +202,7 @@ Comportement :
 | Fichier | Rôle |
 |---|---|
 | `templates/briefing.html` | Template Jinja2 final |
-| `templates/partials/_item.html` | Macro `render_item(item, hero=False)` — réutilisée pour 60s, sections, dont_miss |
+| `templates/partials/_item.html` | Macro `render_item(item, hero=False)` — réutilisée pour sections et dont_miss |
 | `scripts/render.py` (update) | Ajout validation taille + regex anti-CDN |
 | `tests/test_render.py` | 15 tests structuraux sur le HTML produit |
 
@@ -223,11 +223,6 @@ Comportement :
 <header>
   ☀️ BRIEFING MATIN — vendredi 19 avril 2026
 </header>
-
-<section class="sixty-seconds">
-  ⚡ EN 60 SECONDES
-  [3 items en style compact "bullet-like"]
-</section>
 
 <section class="standard" id="ai-tech">
   🤖 AI / Tech

--- a/PRD.md
+++ b/PRD.md
@@ -76,7 +76,6 @@ Le LLM (xAI Grok) reçoit pour chaque appel un prompt structuré. Les templates 
 - `prompts/x_search.txt` — recherche sur un compte X ou un thème
 - `prompts/web_search.txt` — recherche web thématique
 - `prompts/rank.txt` — sélection finale par section (si on excède `max_items`)
-- `prompts/brief_60s.txt` — composition des 3 items "EN 60 SECONDES"
 - `prompts/dont_miss.txt` — sélection du "À NE PAS MANQUER"
 
 **Critères de pertinence** (inclus dans tous les prompts de sélection) :
@@ -86,9 +85,9 @@ Le LLM (xAI Grok) reçoit pour chaque appel un prompt structuré. Les templates 
 4. **Pertinence Chris** : match avec ses intérêts déclarés (cf. section Utilisateur)
 5. **Évitement doublon cross-section** : si un item peut aller dans 2 sections, le placer dans la plus spécifique
 
-**Sélection "EN 60 SECONDES"** : 3 items choisis *après* que toutes les sections sont remplies, parmi l'union des items sélectionnés. Critère : convergence inter-sources (plusieurs sources indépendantes mentionnent le même événement) OU impact mesurable (chiffre, décision réglementaire, launch).
-
 **Sélection "À NE PAS MANQUER"** : 1 item par briefing, choisi dans l'union des items *non retenus* par les sections (pour éviter la redondance). Privilégier : vidéo longue (si matin = queue de la journée) ou thread analytique (si soir = lecture de soirée).
+
+> Note : la section "EN 60 SECONDES" initialement prévue a été retirée via l'[issue #22](https://github.com/chrisboulet/briefing-matinal/issues/22) — redondante avec les sections thématiques et "À NE PAS MANQUER".
 
 ### S2 — Compilation HTML
 
@@ -98,8 +97,6 @@ Le briefing est un fichier HTML standalone rendu par **Jinja2** (décision : pas
 
 ```
 ☀️ BRIEFING MATIN — [jour long FR, date]        (ou 🌙 BRIEFING SOIR)
-─────────────────────
-⚡ EN 60 SECONDES                  — 3 faits marquants
 ─────────────────────
 🤖 AI / TECH                       — 3 items max
 🚗 TESLA                           — 2 items max
@@ -238,7 +235,6 @@ class Briefing:
     generated_at: datetime     # UTC
     window_start: datetime
     window_end: datetime
-    sixty_seconds: list[Item]  # 3 items
     sections: dict[str, list[Item]]  # section_id → items triés
     dont_miss: Item
     config_hash: str           # SHA-256 de comptes.json

--- a/docs/preview/sample-matin.html
+++ b/docs/preview/sample-matin.html
@@ -94,22 +94,6 @@ article:last-of-type { border-bottom: none; }
 <h1>☀️ BRIEFING MATIN — 2026-04-19-matin</h1>
 
 
-<h2>⚡ EN 60 SECONDES</h2>
-<article class="hero">
-<h3><a href="https://x.com/AnthropicAI/status/1814000000000000002" rel="noopener noreferrer">Anthropic ships Claude 5.0 with extended context</a></h3>
-<p>Annonce officielle: 2M tokens context, latence réduite de 40%, prix stable.</p>
-<p class="src">via @AnthropicAI</p>
-</article>
-<article class="hero">
-<h3><a href="https://www.lapresse.ca/international/2026-04-19/trump-ai-export.php" rel="noopener noreferrer">Trump signs executive order on AI export controls</a></h3>
-<p>Décret signé hier soir restreignant l&#39;export de GPU H300+ vers 12 pays.</p>
-<p class="src">via lapresse.ca</p>
-</article>
-<article class="hero">
-<h3><a href="https://x.com/WholeMarsBlog/status/1814000000000000011" rel="noopener noreferrer">FSD v14 broader rollout begins this week</a></h3>
-<p>Tesla démarre rollout FSD v14 sur l&#39;ensemble du parc HW4 en NA.</p>
-<p class="src">via @WholeMarsBlog + 1 autre</p>
-</article>
 
 <h2>🤖 AI / Tech</h2>
 <article>
@@ -193,9 +177,9 @@ article:last-of-type { border-bottom: none; }
 <p class="meta">
 briefing: 2026-04-19-matin ·
 config: 2fbf9c0 ·
-git: 93af264 ·
+git: d8e426e ·
 prompts: prompts-v1.0 ·
-généré: 2026-04-19T20:41:05+00:00
+généré: 2026-04-19T21:12:18+00:00
 </p>
 </body>
 </html>

--- a/scripts/build_briefing.py
+++ b/scripts/build_briefing.py
@@ -20,7 +20,6 @@ from scripts.select import (
     apply_engagement_filter,
     select_by_section,
     select_dont_miss,
-    select_sixty_seconds,
 )
 from scripts.window import briefing_id as compute_briefing_id
 from scripts.window import compute_window
@@ -133,7 +132,6 @@ def build(
     deduped = dedupe(filtered)
 
     sections = select_by_section(deduped, sections_cfg)
-    sixty_sec = select_sixty_seconds(sections, n=3)
     dont_miss = select_dont_miss(deduped, sections)
 
     warnings: list[str] = list(source_warnings)
@@ -147,7 +145,6 @@ def build(
         generated_at=datetime.now(tz=UTC),
         window_start=window_start,
         window_end=window_end,
-        sixty_seconds=sixty_sec,
         sections=sections,
         dont_miss=dont_miss,
         config_hash=cfg_hash,

--- a/scripts/models.py
+++ b/scripts/models.py
@@ -38,7 +38,6 @@ class Briefing:
     generated_at: datetime
     window_start: datetime
     window_end: datetime
-    sixty_seconds: list[Item]
     sections: dict[str, list[Item]]
     dont_miss: Item | None
     config_hash: str
@@ -48,7 +47,7 @@ class Briefing:
 
     @property
     def items_count(self) -> int:
-        n = len(self.sixty_seconds) + sum(len(v) for v in self.sections.values())
+        n = sum(len(v) for v in self.sections.values())
         if self.dont_miss is not None:
             n += 1
         return n

--- a/scripts/select.py
+++ b/scripts/select.py
@@ -1,4 +1,4 @@
-"""Sélection finale par section + sections hero (60s, dont_miss). Voir PRD §S1.bis."""
+"""Sélection finale par section + dont_miss. Voir PRD §S1.bis."""
 
 from __future__ import annotations
 
@@ -28,35 +28,6 @@ def select_by_section(
         max_items = section["max_items"]
         out[sid] = by_section[sid][:max_items]
     return out
-
-
-def select_sixty_seconds(
-    selected: dict[str, list[Item]],
-    n: int = 3,
-) -> list[Item]:
-    """
-    3 items 'EN 60 SECONDES' choisis parmi l'union de toutes les sections.
-    Critère V1 : top par score, en privilégiant la diversité de sections (1 par section idéalement).
-    """
-    pool: list[Item] = [it for items in selected.values() for it in items]
-    pool.sort(key=lambda x: (-x.score, -x.published_at.timestamp(), x.id))
-
-    chosen: list[Item] = []
-    seen_sections: set[str] = set()
-
-    for it in pool:
-        if it.section_id not in seen_sections:
-            chosen.append(it)
-            seen_sections.add(it.section_id)
-            if len(chosen) == n:
-                return chosen
-
-    for it in pool:
-        if it not in chosen:
-            chosen.append(it)
-            if len(chosen) == n:
-                break
-    return chosen
 
 
 def select_dont_miss(

--- a/templates/briefing.html
+++ b/templates/briefing.html
@@ -98,12 +98,8 @@ article:last-of-type { border-bottom: none; }
    internaux de pipeline (items hors fenêtre, sections vides, appels xAI dégradés)
    destinés à stderr et au JSON stdout pour hermes-agent, pas au lecteur final. #}
 
-<h2>⚡ EN 60 SECONDES</h2>
-{% for item in briefing.sixty_seconds %}
-{{ render_item(item, hero=true) }}
-{% else %}
-<p class="empty">Pas assez d'éléments marquants pour un résumé express.</p>
-{% endfor %}
+{# Section 'EN 60 SECONDES' retirée (issue #22) : les items y étaient redondants
+   avec leurs sections thématiques respectives. #}
 
 {% for section in sections_in_order %}
 <h2>{{ section.emoji }} {{ section.label }}</h2>

--- a/tests/test_e2e_offline.py
+++ b/tests/test_e2e_offline.py
@@ -21,7 +21,7 @@ def test_e2e_matin_with_fixture(tmp_path: Path):
     assert html_path.exists()
     html = html_path.read_text(encoding="utf-8")
     assert "BRIEFING MATIN" in html
-    assert "EN 60 SECONDES" in html
+    assert "EN 60 SECONDES" not in html  # retiré via issue #22
 
 
 def test_e2e_idempotence(tmp_path: Path):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -30,7 +30,6 @@ def minimal_briefing(make_item) -> Briefing:
         generated_at=datetime(2026, 4, 19, 10, 44, tzinfo=UTC),
         window_start=datetime(2026, 4, 18, 21, 30, tzinfo=UTC),
         window_end=datetime(2026, 4, 19, 10, 30, tzinfo=UTC),
-        sixty_seconds=[a, t, p],
         sections={"ai-tech": [a], "tesla": [t], "spacex": [], "sante": [], "politique": [p], "business": []},
         dont_miss=dm,
         config_hash="abc1234567890",
@@ -49,7 +48,7 @@ def test_render_produces_html(minimal_briefing, sections_cfg):
 def test_render_contains_key_sections(minimal_briefing, sections_cfg):
     html, _ = render(minimal_briefing, sections_cfg)
     assert "BRIEFING MATIN" in html
-    assert "EN 60 SECONDES" in html
+    assert "EN 60 SECONDES" not in html  # retiré via issue #22
     assert "À NE PAS MANQUER" in html
     for section in sections_cfg:
         assert section["label"] in html
@@ -64,10 +63,9 @@ def test_render_no_cdn(minimal_briefing, sections_cfg):
 
 def test_render_blocks_cdn_in_summary(minimal_briefing, sections_cfg):
     bad = replace(
-        minimal_briefing.sixty_seconds[0],
+        minimal_briefing.sections["ai-tech"][0],
         summary="See https://fonts.googleapis.com/css?foo for details",
     )
-    minimal_briefing.sixty_seconds[0] = bad
     minimal_briefing.sections["ai-tech"][0] = bad
     with pytest.raises(RenderError, match="CDN"):
         render(minimal_briefing, sections_cfg)
@@ -87,7 +85,6 @@ def test_render_dark_mode_css_present(minimal_briefing, sections_cfg):
 
 def test_render_escapes_dangerous_titles(make_item, sections_cfg, minimal_briefing):
     evil = make_item('<script>alert(1)</script>', "https://e.com/x", section_id="ai-tech")
-    minimal_briefing.sixty_seconds = [evil]
     minimal_briefing.sections["ai-tech"] = [evil]
     html, _ = render(minimal_briefing, sections_cfg)
     assert "<script>alert(1)</script>" not in html
@@ -96,10 +93,11 @@ def test_render_escapes_dangerous_titles(make_item, sections_cfg, minimal_briefi
 
 def test_render_alt_sources_pluralized(make_item, sections_cfg, minimal_briefing):
     one = make_item("a", "https://e.com/1", section_id="ai-tech")
+    two = make_item("b", "https://e.com/2", section_id="tesla")
     one_alt = replace(one, alt_sources=("@x",))
-    two_alt = replace(one, alt_sources=("@x", "@y"))
+    two_alt = replace(two, alt_sources=("@x", "@y"))
     minimal_briefing.sections["ai-tech"] = [one_alt]
-    minimal_briefing.sixty_seconds = [two_alt]
+    minimal_briefing.sections["tesla"] = [two_alt]
     html, _ = render(minimal_briefing, sections_cfg)
     assert "+ 1 autre" in html
     assert "+ 2 autres" in html
@@ -146,8 +144,8 @@ def test_render_idempotent_for_same_briefing(minimal_briefing, sections_cfg):
 
 def test_render_warning_when_size_overflows(make_item, sections_cfg, minimal_briefing):
     bloat_summary = "x" * 70_000
-    fat = replace(minimal_briefing.sixty_seconds[0], summary=bloat_summary)
-    minimal_briefing.sixty_seconds = [fat]
+    fat = replace(minimal_briefing.sections["ai-tech"][0], summary=bloat_summary)
+    minimal_briefing.sections["ai-tech"] = [fat]
     html, warnings = render(minimal_briefing, sections_cfg)
     assert any("budget" in w for w in warnings)
     assert len(html.encode("utf-8")) > SIZE_BUDGET_BYTES

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -6,7 +6,6 @@ from scripts.select import (
     apply_engagement_filter,
     select_by_section,
     select_dont_miss,
-    select_sixty_seconds,
 )
 
 SECTIONS_CFG = [
@@ -42,33 +41,6 @@ def test_select_by_section_empty_section(make_item):
     out = select_by_section(items, SECTIONS_CFG)
     assert out["ai-tech"]
     assert out["tesla"] == []
-
-
-def test_select_60s_diversifies_sections(make_item):
-    selected = {
-        "ai-tech": [
-            make_item("ai1", "https://e.com/1", section_id="ai-tech", score=0.95),
-            make_item("ai2", "https://e.com/2", section_id="ai-tech", score=0.94),
-        ],
-        "tesla": [make_item("t1", "https://e.com/3", section_id="tesla", score=0.80)],
-        "spacex": [make_item("s1", "https://e.com/4", section_id="spacex", score=0.70)],
-    }
-    out = select_sixty_seconds(selected, n=3)
-    assert len(out) == 3
-    sections = {it.section_id for it in out}
-    assert sections == {"ai-tech", "tesla", "spacex"}
-
-
-def test_select_60s_falls_back_when_few_sections(make_item):
-    selected = {
-        "ai-tech": [
-            make_item("ai1", "https://e.com/1", section_id="ai-tech", score=0.95),
-            make_item("ai2", "https://e.com/2", section_id="ai-tech", score=0.94),
-            make_item("ai3", "https://e.com/3", section_id="ai-tech", score=0.93),
-        ],
-    }
-    out = select_sixty_seconds(selected, n=3)
-    assert len(out) == 3
 
 
 def test_select_dont_miss_avoids_redundancy(make_item):


### PR DESCRIPTION
Closes #22.

## Diff net : -92 lignes

Retrait complet de la section "EN 60 SECONDES" à travers tout le stack (data model → logique → template → tests → docs → preview).

## Chirurgie

| Couche | Action |
|---|---|
| `scripts/models.py` | Champ `sixty_seconds: list[Item]` retiré de `Briefing`, `items_count` simplifié |
| `scripts/select.py` | `select_sixty_seconds()` supprimée |
| `scripts/build_briefing.py` | Import + appel retirés |
| `templates/briefing.html` | Bloc `<h2>⚡ EN 60 SECONDES</h2>` + boucle retirés, remplacés par commentaire Jinja explicatif (dissuade réintroduction) |
| `tests/test_select.py` | 2 tests `test_select_60s_*` + import retirés |
| `tests/test_render.py` | Fixture + 4 tests qui manipulaient `sixty_seconds` migrés vers `sections['ai-tech']`. Assertion `"EN 60 SECONDES" in html` inversée en `not in html` |
| `tests/test_e2e_offline.py` | Même inversion assertion |
| `PRD.md` | Bloc "Sélection EN 60 SECONDES" retiré avec note historique pointant #22 ; ligne dans le template ASCII + champ du data model example retirés |
| `PLAN.md` | Bloc HTML example + références retirés |
| `CLAUDE.md` | Mentions "60s" dans arbo + flux retirées |
| `docs/preview/sample-matin.html` | Régénéré |

## Impact briefing

| Métrique | Avant | Après | Δ |
|---|---|---|---|
| Items dans fixture preview | 17 | 14 | -3 (les 3 items 60s qui dupliquaient les sections) |
| Taille HTML (preview) | 7776 B | 6818 B | **-12%** |
| Tests | 127 | 125 | -2 (tests 60s supprimés, cohérent) |
| Lines of code | | | -92 net |

## Validations

- [x] `pytest -q` → **125/125 verts**
- [x] `ruff check .` → All checks passed
- [x] `grep -c '60 SECONDES\|sixty' docs/preview/sample-matin.html` → **0**

## Prochain

Enchaîne sur **#23** (synthèses ~500 chars + `<details>/<summary>` collapsed). La refonte structurelle du rendu arrive dans un PR séparé pour traçabilité.

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo