### PR TITLE
feat(template): items collapsed via &lt;details&gt;/&lt;summary&gt; + summaries ~500 chars (closes #23)

### DIFF
--- a/docs/preview/sample-matin.html
+++ b/docs/preview/sample-matin.html
@@ -53,31 +53,55 @@ h2 {
   margin: 1.75rem 0 .75rem;
   letter-spacing: .01em;
 }
-h3 {
-  font-size: 1rem;
-  line-height: 1.35;
-  margin: 0 0 .35rem;
-  font-weight: 600;
-}
 p { margin: .35rem 0; }
 a { color: var(--link); text-decoration: none; }
 a:hover, a:focus { color: var(--link-hov); text-decoration: underline; }
 article {
-  margin: 0 0 .9rem;
-  padding-bottom: .85rem;
+  margin: 0 0 .7rem;
+  padding-bottom: .55rem;
   border-bottom: 1px solid var(--border);
 }
 article:last-of-type { border-bottom: none; }
+/* Items repliés par défaut (issue #23) — summary = titre cliquable (toggle),
+   body = synthèse + lien "Lire ↗". */
+details { margin: 0; }
+details summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.35;
+  padding: .3rem 0;
+  list-style: none;
+  color: var(--fg);
+}
+details summary::-webkit-details-marker { display: none; }
+details summary::before {
+  content: "▸";
+  display: inline-block;
+  color: var(--muted);
+  font-size: .85em;
+  margin-right: .4rem;
+  width: .8em;
+}
+details[open] summary::before { content: "▾"; }
+details .body {
+  margin: .4rem 0 .2rem;
+  padding-left: 1.2rem;
+  line-height: 1.55;
+}
+details .src {
+  padding-left: 1.2rem;
+}
 .src { color: var(--muted); font-size: .85rem; margin-top: .25rem; }
 .hero {
   background: var(--hero-bg);
   border-left: 4px solid var(--hero-accent);
-  padding: .85rem 1rem;
+  padding: .75rem 1rem;
   border-radius: 4px;
   margin-bottom: .75rem;
   border-bottom: none;
 }
-.hero h3 { font-size: 1.05rem; }
+.hero details summary { font-size: 1.05rem; color: var(--hero-accent); }
 .empty { color: var(--muted); font-style: italic; font-size: .9rem; }
 .meta {
   color: var(--muted);
@@ -97,89 +121,117 @@ article:last-of-type { border-bottom: none; }
 
 <h2>🤖 AI / Tech</h2>
 <article>
-<h3><a href="https://x.com/AnthropicAI/status/1814000000000000002" rel="noopener noreferrer">Anthropic ships Claude 5.0 with extended context</a></h3>
-<p>Annonce officielle: 2M tokens context, latence réduite de 40%, prix stable.</p>
-<p class="src">via @AnthropicAI</p>
+<details>
+<summary>Anthropic ships Claude 5.0 with extended context</summary>
+<p class="body">Annonce officielle: 2M tokens context, latence réduite de 40%, prix stable.</p>
+<p class="src">via @AnthropicAI · <a href="https://x.com/AnthropicAI/status/1814000000000000002" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <article>
-<h3><a href="https://x.com/karpathy/status/1814000000000000001" rel="noopener noreferrer">Karpathy on agentic coding patterns</a></h3>
-<p>Long thread sur les patterns émergents en agentic coding et leurs implications design.</p>
-<p class="src">via @karpathy</p>
+<details>
+<summary>Karpathy on agentic coding patterns</summary>
+<p class="body">Long thread sur les patterns émergents en agentic coding et leurs implications design.</p>
+<p class="src">via @karpathy · <a href="https://x.com/karpathy/status/1814000000000000001" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <article>
-<h3><a href="https://x.com/OpenAI/status/1814000000000000003" rel="noopener noreferrer">OpenAI release: GPT-5 Multi tool</a></h3>
-<p>Nouveau mode multi-tool concurrent, approche similaire au flow Anthropic.</p>
-<p class="src">via @OpenAI</p>
+<details>
+<summary>OpenAI release: GPT-5 Multi tool</summary>
+<p class="body">Nouveau mode multi-tool concurrent, approche similaire au flow Anthropic.</p>
+<p class="src">via @OpenAI · <a href="https://x.com/OpenAI/status/1814000000000000003" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <h2>🚗 Tesla</h2>
 <article>
-<h3><a href="https://x.com/WholeMarsBlog/status/1814000000000000011" rel="noopener noreferrer">FSD v14 broader rollout begins this week</a></h3>
-<p>Tesla démarre rollout FSD v14 sur l&#39;ensemble du parc HW4 en NA.</p>
-<p class="src">via @WholeMarsBlog + 1 autre</p>
+<details>
+<summary>FSD v14 broader rollout begins this week</summary>
+<p class="body">Tesla démarre rollout FSD v14 sur l&#39;ensemble du parc HW4 en NA.</p>
+<p class="src">via @WholeMarsBlog + 1 autre · <a href="https://x.com/WholeMarsBlog/status/1814000000000000011" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <article>
-<h3><a href="https://x.com/cernbasher/status/1814000000000000010" rel="noopener noreferrer">Cybertruck production hits 250k unit milestone</a></h3>
-<p>Tesla franchit le cap des 250k Cybertrucks produits depuis le lancement.</p>
-<p class="src">via @cernbasher</p>
+<details>
+<summary>Cybertruck production hits 250k unit milestone</summary>
+<p class="body">Tesla franchit le cap des 250k Cybertrucks produits depuis le lancement.</p>
+<p class="src">via @cernbasher · <a href="https://x.com/cernbasher/status/1814000000000000010" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <h2>🚀 SpaceX</h2>
 <article>
-<h3><a href="https://x.com/SpaceX/status/1814000000000000021" rel="noopener noreferrer">Starlink V3 sats: 60 launched overnight</a></h3>
-<p>60 satellites V3 déployés cette nuit depuis Vandenberg, capacité +35%.</p>
-<p class="src">via @SpaceX</p>
+<details>
+<summary>Starlink V3 sats: 60 launched overnight</summary>
+<p class="body">60 satellites V3 déployés cette nuit depuis Vandenberg, capacité +35%.</p>
+<p class="src">via @SpaceX · <a href="https://x.com/SpaceX/status/1814000000000000021" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <h2>🏥 Santé</h2>
 <article>
-<h3><a href="https://x.com/davidasinclair/status/1814000000000000030" rel="noopener noreferrer">Sinclair: NMN longitudinal trial 2-year results</a></h3>
-<p>Étude 2 ans sur 800 sujets, marqueurs biologiques améliorés sur 6 axes.</p>
-<p class="src">via @davidasinclair</p>
+<details>
+<summary>Sinclair: NMN longitudinal trial 2-year results</summary>
+<p class="body">Étude 2 ans sur 800 sujets, marqueurs biologiques améliorés sur 6 axes.</p>
+<p class="src">via @davidasinclair · <a href="https://x.com/davidasinclair/status/1814000000000000030" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <article>
-<h3><a href="https://x.com/PeterAttiaMD/status/1814000000000000031" rel="noopener noreferrer">Attia: practical Zone 2 protocol update</a></h3>
-<p>Refonte du protocole Zone 2 basée sur 18 mois de données patients.</p>
-<p class="src">via @PeterAttiaMD</p>
+<details>
+<summary>Attia: practical Zone 2 protocol update</summary>
+<p class="body">Refonte du protocole Zone 2 basée sur 18 mois de données patients.</p>
+<p class="src">via @PeterAttiaMD · <a href="https://x.com/PeterAttiaMD/status/1814000000000000031" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <h2>🏛️ Politique</h2>
 <article>
-<h3><a href="https://www.lapresse.ca/international/2026-04-19/trump-ai-export.php" rel="noopener noreferrer">Trump signs executive order on AI export controls</a></h3>
-<p>Décret signé hier soir restreignant l&#39;export de GPU H300+ vers 12 pays.</p>
-<p class="src">via lapresse.ca</p>
+<details>
+<summary>Trump signs executive order on AI export controls</summary>
+<p class="body">Décret signé hier soir restreignant l&#39;export de GPU H300+ vers 12 pays.</p>
+<p class="src">via lapresse.ca · <a href="https://www.lapresse.ca/international/2026-04-19/trump-ai-export.php" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <article>
-<h3><a href="https://www.journaldequebec.com/2026/04/19/budget-supplementaire-sante-2026" rel="noopener noreferrer">Legault annonce un budget supplémentaire en santé</a></h3>
-<p>Le gouvernement du Québec ajoute 2,3 G$ au budget santé pour l&#39;exercice en cours.</p>
-<p class="src">via journaldequebec.com</p>
+<details>
+<summary>Legault annonce un budget supplémentaire en santé</summary>
+<p class="body">Le gouvernement du Québec ajoute 2,3 G$ au budget santé pour l&#39;exercice en cours.</p>
+<p class="src">via journaldequebec.com · <a href="https://www.journaldequebec.com/2026/04/19/budget-supplementaire-sante-2026" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <article>
-<h3><a href="https://www.lapresse.ca/international/2026-04-19/taiwan-survol.php" rel="noopener noreferrer">Tensions Taiwan: nouveau survol PLAAF</a></h3>
-<p>12 appareils PLAAF traversent la ligne médiane, plus haute fréquence depuis février.</p>
-<p class="src">via lapresse.ca</p>
+<details>
+<summary>Tensions Taiwan: nouveau survol PLAAF</summary>
+<p class="body">12 appareils PLAAF traversent la ligne médiane, plus haute fréquence depuis février.</p>
+<p class="src">via lapresse.ca · <a href="https://www.lapresse.ca/international/2026-04-19/taiwan-survol.php" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <h2>💼 Business</h2>
 <article>
-<h3><a href="https://www.lesaffaires.com/entreprises/bce-distributel-2026" rel="noopener noreferrer">BCE rachète Distributel pour 1,8 G$</a></h3>
-<p>Acquisition annoncée hier soir, attend approbation CRTC.</p>
-<p class="src">via lesaffaires.com</p>
+<details>
+<summary>BCE rachète Distributel pour 1,8 G$</summary>
+<p class="body">Acquisition annoncée hier soir, attend approbation CRTC.</p>
+<p class="src">via lesaffaires.com · <a href="https://www.lesaffaires.com/entreprises/bce-distributel-2026" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 <article>
-<h3><a href="https://www.lesaffaires.com/marches/tsx-cloture-2026-04-18" rel="noopener noreferrer">TSX clôture en hausse de 1.2%, énergie en tête</a></h3>
-<p>Indice composé TSX +1.2% sur la séance, secteur énergie tire la performance.</p>
-<p class="src">via lesaffaires.com</p>
+<details>
+<summary>TSX clôture en hausse de 1.2%, énergie en tête</summary>
+<p class="body">Indice composé TSX +1.2% sur la séance, secteur énergie tire la performance.</p>
+<p class="src">via lesaffaires.com · <a href="https://www.lesaffaires.com/marches/tsx-cloture-2026-04-18" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 
 <h2>📌 À NE PAS MANQUER</h2>
 <article class="hero">
-<h3><a href="https://danielmiessler.com/blog/ai-alignment-2026" rel="noopener noreferrer">Daniel Miessler: AI alignment, the 2026 take</a></h3>
-<p>Essai sur l&#39;évolution du discours alignment depuis 2024.</p>
-<p class="src">via @DanielMiessler</p>
+<details>
+<summary>Daniel Miessler: AI alignment, the 2026 take</summary>
+<p class="body">Essai sur l&#39;évolution du discours alignment depuis 2024.</p>
+<p class="src">via @DanielMiessler · <a href="https://danielmiessler.com/blog/ai-alignment-2026" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 
 <p class="meta">
 briefing: 2026-04-19-matin ·
 config: 2fbf9c0 ·
-git: d8e426e ·
+git: d68732a ·
 prompts: prompts-v1.0 ·
-généré: 2026-04-19T21:12:18+00:00
+généré: 2026-04-19T21:16:43+00:00
 </p>
 </body>
 </html>

--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -35,7 +35,7 @@ For each retained tool result:
 1. Map `link` → `canonical_url`
 2. Map `engagement.likes` → `likes`, `engagement.reposts` → `reposts`
 3. **Synthesize a clean `title`** (3-12 words) — do NOT copy the first line of `content` verbatim. The title should be a headline, not a tweet excerpt. Strip thread markers (`🧵`, `1/12`), leading attributions, and trailing URLs.
-4. Write `summary` in Quebec French (1-2 lines, telegraphic, factual)
+4. Write `summary` in Quebec French — **~400-500 characters** (3-5 phrases, substantiel, factuel, journalistic). The summary is displayed when the reader expands the item, so it must give enough context to decide whether to open the source link. Include: what happened, key numbers/names, and why it matters in 1-2 words (don't editorialize).
 5. Parse `source_handle` from author field (e.g., `"Financial Times (@FT)"` → `"@FT"`)
 6. Classify `section_id` (see section list in each prompt)
 7. Assign `score` based on the quality bar

--- a/scripts/sourcing.py
+++ b/scripts/sourcing.py
@@ -502,8 +502,10 @@ def _to_item(
         title = _derive_title_from_content(raw.get("content") or "")
 
     # Summary : explicit ou `content` (truncate pour budget rendu)
+    # Cap 1200 chars : le prompt demande ~400-500 (issue #23) ; on laisse
+    # de la marge sans que ça explose le budget lisibilité du HTML.
     summary = raw.get("summary") or raw.get("content") or title
-    summary = str(summary)[:800]
+    summary = str(summary)[:1200]
 
     # Source handle : explicit ou parse de `author` ("Name (@handle)")
     source_handle = raw.get("source_handle")

--- a/scripts/xai_client.py
+++ b/scripts/xai_client.py
@@ -94,7 +94,7 @@ ITEMS_SCHEMA: dict[str, Any] = {
                 ],
                 "properties": {
                     "title": {"type": "string", "minLength": 1, "maxLength": 500},
-                    "summary": {"type": "string", "minLength": 1, "maxLength": 1000},
+                    "summary": {"type": "string", "minLength": 1, "maxLength": 1200},
                     "canonical_url": {"type": "string", "minLength": 1},
                     "source_type": {"enum": ["x_account", "x_search", "web"]},
                     "source_handle": {"type": "string", "minLength": 1},

--- a/templates/briefing.html
+++ b/templates/briefing.html
@@ -53,31 +53,55 @@ h2 {
   margin: 1.75rem 0 .75rem;
   letter-spacing: .01em;
 }
-h3 {
-  font-size: 1rem;
-  line-height: 1.35;
-  margin: 0 0 .35rem;
-  font-weight: 600;
-}
 p { margin: .35rem 0; }
 a { color: var(--link); text-decoration: none; }
 a:hover, a:focus { color: var(--link-hov); text-decoration: underline; }
 article {
-  margin: 0 0 .9rem;
-  padding-bottom: .85rem;
+  margin: 0 0 .7rem;
+  padding-bottom: .55rem;
   border-bottom: 1px solid var(--border);
 }
 article:last-of-type { border-bottom: none; }
+/* Items repliés par défaut (issue #23) — summary = titre cliquable (toggle),
+   body = synthèse + lien "Lire ↗". */
+details { margin: 0; }
+details summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.35;
+  padding: .3rem 0;
+  list-style: none;
+  color: var(--fg);
+}
+details summary::-webkit-details-marker { display: none; }
+details summary::before {
+  content: "▸";
+  display: inline-block;
+  color: var(--muted);
+  font-size: .85em;
+  margin-right: .4rem;
+  width: .8em;
+}
+details[open] summary::before { content: "▾"; }
+details .body {
+  margin: .4rem 0 .2rem;
+  padding-left: 1.2rem;
+  line-height: 1.55;
+}
+details .src {
+  padding-left: 1.2rem;
+}
 .src { color: var(--muted); font-size: .85rem; margin-top: .25rem; }
 .hero {
   background: var(--hero-bg);
   border-left: 4px solid var(--hero-accent);
-  padding: .85rem 1rem;
+  padding: .75rem 1rem;
   border-radius: 4px;
   margin-bottom: .75rem;
   border-bottom: none;
 }
-.hero h3 { font-size: 1.05rem; }
+.hero details summary { font-size: 1.05rem; color: var(--hero-accent); }
 .empty { color: var(--muted); font-style: italic; font-size: .9rem; }
 .meta {
   color: var(--muted);

--- a/templates/partials/_item.html
+++ b/templates/partials/_item.html
@@ -1,8 +1,12 @@
-{# Macro de rendu d'un item. hero=True applique le style mis en valeur. #}
+{# Macro de rendu d'un item. hero=True applique le style mis en valeur.
+   Structure details/summary (issue #23) : titre = toggle (collapsed par défaut),
+   synthèse + lien externe dans le corps expandable. #}
 {%- macro render_item(item, hero=False) -%}
 <article{% if hero %} class="hero"{% endif %}>
-<h3><a href="{{ item.short_url or item.canonical_url }}" rel="noopener noreferrer">{{ item.title }}</a></h3>
-<p>{{ item.summary }}</p>
-<p class="src">via {{ item.source_handle }}{% if item.alt_sources %} + {{ item.alt_sources|length }} autre{% if item.alt_sources|length > 1 %}s{% endif %}{% endif %}</p>
+<details>
+<summary>{{ item.title }}</summary>
+<p class="body">{{ item.summary }}</p>
+<p class="src">via {{ item.source_handle }}{% if item.alt_sources %} + {{ item.alt_sources|length }} autre{% if item.alt_sources|length > 1 %}s{% endif %}{% endif %} · <a href="{{ item.short_url or item.canonical_url }}" rel="noopener noreferrer">Lire ↗</a></p>
+</details>
 </article>
 {%- endmacro -%}

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -131,6 +131,49 @@ def test_render_links_have_rel_noopener(minimal_briefing, sections_cfg):
     assert all('rel="noopener noreferrer"' in a for a in article_anchors)
 
 
+def test_render_items_wrapped_in_details(minimal_briefing, sections_cfg):
+    """Issue #23 : chaque item doit être dans un <details> collapsed par défaut."""
+    html, _ = render(minimal_briefing, sections_cfg)
+    # Compte le nombre d'items total (sections + dont_miss)
+    total_items = sum(len(v) for v in minimal_briefing.sections.values())
+    if minimal_briefing.dont_miss:
+        total_items += 1
+    # Chaque item = 1 <details>
+    assert html.count("<details>") == total_items
+    assert html.count("</details>") == total_items
+
+
+def test_render_summary_contains_title(minimal_briefing, sections_cfg):
+    """Le titre de l'item doit apparaître dans le <summary>, pas dans un <h3>."""
+    html, _ = render(minimal_briefing, sections_cfg)
+    first_item = minimal_briefing.sections["ai-tech"][0]
+    # Le titre est dans un <summary>, pas un <h3>
+    assert f"<summary>{first_item.title}</summary>" in html
+    # h3 ne doit plus exister côté items
+    assert "<h3>" not in html
+
+
+def test_render_details_collapsed_by_default(minimal_briefing, sections_cfg):
+    """Aucun <details> ne doit avoir l'attribut `open` par défaut — l'item
+    est replié à l'ouverture du briefing (Chris scanne les titres)."""
+    html, _ = render(minimal_briefing, sections_cfg)
+    assert "<details open>" not in html
+    assert "<details open=" not in html
+
+
+def test_render_link_lire_outside_summary(minimal_briefing, sections_cfg):
+    """Le lien 'Lire ↗' doit être dans le corps expandable, pas dans le
+    <summary> (pour éviter le conflit click-toggle vs click-navigate)."""
+    html, _ = render(minimal_briefing, sections_cfg)
+    # Entre chaque <summary>...</summary>, aucun <a> ne doit être présent
+    between_summary = re.findall(r"<summary>(.*?)</summary>", html, re.DOTALL)
+    assert between_summary, "expected at least one <summary>"
+    for content in between_summary:
+        assert "<a " not in content, f"found <a> inside <summary>: {content[:80]}"
+    # Mais le lien "Lire ↗" doit être présent ailleurs
+    assert "Lire ↗" in html
+
+
 def test_render_minimum_font_size_15px(minimal_briefing, sections_cfg):
     html, _ = render(minimal_briefing, sections_cfg)
     assert "16px" in html  # html base font-size


### PR DESCRIPTION
Closes #23.

## UX cible (rappel)

Chris lit le briefing sur Android via fichier HTML poussé par hermes-agent. Workflow :

1. **Scanner** les titres collapsed (vue d'ensemble en 10 secondes)
2. **Ouvrir** un item intéressant → lire la synthèse substantielle (~500 chars)
3. **Cliquer "Lire ↗"** depuis la synthèse → ouvrir la source externe
4. Back button Android → retour au briefing avec l'item toujours expanded

## Refonte template

### `templates/partials/_item.html`

| Avant | Après |
|---|---|
| `<h3><a href="url">Titre</a></h3>` | `<summary>Titre</summary>` (le toggle) |
| `<p>Summary</p>` (court) | `<p class="body">Summary ~500 chars</p>` (dans `<details>`) |
| `<p class="src">via @x</p>` | `<p class="src">via @x · <a href="url">Lire ↗</a></p>` |

Le titre devient le toggle (non cliquable vers l'URL). Le lien vers la source est dans le corps avec label "Lire ↗" — évite le conflit click-toggle vs click-navigate.

### `templates/briefing.html` — CSS

- `h3` retiré (plus utilisé)
- Règles `details`, `details summary`, `details[open]`, `details .body`, `details .src`
- Chevron custom `▸`/`▾` via `::before` (list-marker natif masqué cross-browser)
- Hero items : couleur accent sur summary + font-size bump

## Prompts

`prompts/system.txt` étape 4 réécrite : le `summary` doit être **400-500 chars (3-5 phrases), substantiel, journalistic**. C'est l'écran principal après expansion — doit donner assez de contexte pour décider d'ouvrir la source. Rappel : pas d'éditorialisation, factuel.

## Code

- `xai_client.py` : `ITEMS_SCHEMA.summary.maxLength` 1000 → **1200** (marge LLM)
- `sourcing.py` : cap `_to_item` summary 800 → **1200 chars** (aligné prompt)

## Tests (+4)

- `test_render_items_wrapped_in_details` : chaque item = 1 `<details>`
- `test_render_summary_contains_title` : titre dans `<summary>`, plus de `<h3>`
- `test_render_details_collapsed_by_default` : aucun attribut `open`
- `test_render_link_lire_outside_summary` : pas de `<a>` dans `<summary>`, "Lire ↗" présent ailleurs

**129/129 tests verts** (+4 vs 125).

## Validations

- [x] `pytest -q` → 129/129
- [x] `ruff check .` → All checks passed
- [x] Preview régénéré : 14 items, 8.2 KB (+21% vs 6.8 après #22 — coût CSS details + texte "Lire ↗"), **6× sous budget 50 KB**

## À tester côté toi (rendu visuel Android)

- Ouvrir `docs/preview/sample-matin.html` sur ton téléphone
- Tous les titres doivent être **collapsed** par défaut
- Cliquer un titre → expand smooth avec chevron qui tourne (▸ → ▾)
- Cliquer "Lire ↗" → ouvre la source dans Chrome, back button revient au briefing avec l'item toujours expanded

Si sur ton Android Chrome l'animation ou le chevron rendent mal, on peut tuner CSS dans un follow-up rapide.

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo