### PR TITLE
feat(prompts): synthèses 500 → 700-900 chars

### DIFF
--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -35,7 +35,7 @@ For each retained tool result:
 1. Map `link` → `canonical_url`
 2. Map `engagement.likes` → `likes`, `engagement.reposts` → `reposts`
 3. **Synthesize a clean `title`** (3-12 words) — do NOT copy the first line of `content` verbatim. The title should be a headline, not a tweet excerpt. Strip thread markers (`🧵`, `1/12`), leading attributions, and trailing URLs.
-4. Write `summary` in Quebec French — **~400-500 characters** (3-5 phrases, substantiel, factuel, journalistic). The summary is displayed when the reader expands the item, so it must give enough context to decide whether to open the source link. Include: what happened, key numbers/names, and why it matters in 1-2 words (don't editorialize).
+4. Write `summary` in Quebec French — **~700-900 characters** (5-8 phrases, substantiel, factuel, journalistic). The summary is displayed when the reader expands the item, so it must give enough context to decide whether to open the source link. Include: what happened, key numbers/names, relevant background, and why it matters in 1-2 words (don't editorialize).
 5. Parse `source_handle` from author field (e.g., `"Financial Times (@FT)"` → `"@FT"`)
 6. Classify `section_id` (see section list in each prompt)
 7. Assign `score` based on the quality bar


### PR DESCRIPTION
Feedback Chris après premier round de `<details>/<summary>` mergé (#27) : rendu validé sur Android, mais synthèses un peu courtes.

## Changement

`prompts/system.txt` étape 4 :
- **Avant** : ~400-500 chars (3-5 phrases)
- **Après** : **~700-900 chars (5-8 phrases)**

Nouveau descriptif ajoute "relevant background" aux instructions de contenu.

## Pas besoin de toucher

- `scripts/xai_client.py` ITEMS_SCHEMA summary maxLength = **1200** ✓
- `scripts/sourcing.py` `_to_item` cap = **1200** ✓

Les deux laissent déjà la marge pour 900+ chars.

## Validations

- [x] `pytest -q` → 129/129 verts
- [x] `ruff check .` → All checks passed

## Impact attendu

- Taille HTML par briefing : +5-10 KB potentiel (14 items × ~300 chars de plus × overhead HTML). Probablement ~13-16 KB total vs 8.2 KB actuel. Toujours sous budget 50 KB.
- Coût tokens output : +~50% (300 chars ≈ 100 tokens × 14 items = +1.4K tokens par briefing). Négligeable (<0.001 $).

## À tester au prochain run live

Chris valide que la longueur est bonne ; si encore insuffisant on peut pousser à 1000-1200 (la marge code est déjà prête).

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo