### PR TITLE
feat(enrichment): 2e passe web_search (closes #25)

### DIFF
--- a/docs/xai-integration.md
+++ b/docs/xai-integration.md
@@ -209,9 +209,101 @@ Marqués `# TODO(live):` dans le code. Liste à jour :
 4. Headers de rate limit (`X-RateLimit-*` ou autre) — pas encore observés.
 5. Shape des items retournés par le LLM : est-ce que les champs `title/summary/canonical_url/section_id/...` sont respectés, ou est-ce que le modèle renvoie sa propre shape (`post_id/author/content/...`) malgré le schema strict ? — à surveiller sur le prochain test live, peut nécessiter un adaptateur dans `sourcing._to_item()`.
 
+## Enrichissement 2e passe (issue #25)
+
+Depuis `prompts-v1.1`, le pipeline exécute un **2e appel xAI par item sélectionné** pour produire un résumé substantiel (700-900 chars FR-QC) à partir du contenu web complet. Implémenté dans `scripts/enrichment.py` et hooké dans `scripts/build_briefing.build()` **après** `select_by_section` + `select_dont_miss`, **avant** la construction du `Briefing`.
+
+### Pourquoi
+
+La 1re passe (`source_briefing`) produit des `summary` courts à partir du `content` du post X (~150-300 chars, issue #23 les porte à 700-900 mais ce budget n'est atteignable que sur les sources web). Pour les items web, un 2e appel `web_search` restreint au domaine de l'URL permet d'extraire le body complet et de synthétiser un résumé journalistique complet au même budget.
+
+### Hook point
+
+```
+build()
+  ├── source_briefing()             ← 1re passe (multi-items via x_search/web_search)
+  ├── dedupe + select_by_section    ← ~15-20 items survivants
+  ├── select_dont_miss
+  ├── enrich_selected()             ← 2e passe (web_search par item)  ← ICI
+  └── Briefing(sections, dont_miss, …)
+```
+
+Les deux passes partagent le MÊME `XAIClient` (1 `httpx.Client` réutilisé) pour économiser les handshakes TLS.
+
+### Kill switch
+
+Exporter **`BRIEFING_ENRICH=0`** pour désactiver l'enrichissement sans toucher au code. Utile pour :
+- Dégrader d'urgence si le budget xAI explose ;
+- Régénérer un briefing rapidement en mode "à l'os" (1re passe seule) ;
+- Tester les deux modes en parallèle.
+
+Défaut : `BRIEFING_ENRICH=1` (actif). Ignoré en mode `--fixture` (pas de vrai client xAI disponible).
+
+### Budget
+
+| Métrique | Valeur |
+|---|---|
+| Appels additionnels | 1 par item enrichi (items X/Twitter skippés — redondants avec 1re passe) |
+| Items typiques par briefing | ~10-15 (après dedup + quotas) dont ~5-8 web à enrichir |
+| Tool fees | ~5-8 × 0.005 $ ≈ **+0.03-0.04 $/briefing** |
+| Tokens (estim.) | ~2K input + ~1K output par item × 7 ≈ 14K in / 7K out ≈ **+0.007 $/briefing** |
+| Latence | Parallélisé via `ThreadPoolExecutor(max_workers=4)`, deadline globale **30s** (`GLOBAL_DEADLINE_S`), per-item 20s (`DEFAULT_PER_ITEM_TIMEOUT_S`) |
+| **Total delta** | **~+0.05-0.10 $/briefing**, **+30s** latence max |
+
+Budget global révisé avec enrichissement actif : ~**0.15-0.25 $ par briefing × 2/jour ≈ 0.30-0.50 $/jour ≈ 9-15 $/mois**.
+
+### Schema override pattern
+
+L'enrichissement utilise une shape de réponse **single-item** (`{summary, warnings}`), différente du multi-items `{items: [...], warnings: [...]}` du sourcing. Pour permettre ça, `XAIClient.call()` accepte depuis issue #25 deux paramètres optionnels :
+
+```python
+client.call(
+    system_prompt="",              # system inline dans enrich.txt
+    user_prompt=user_prompt,
+    tool="web_search",
+    tool_params={"allowed_domains": [hostname]},
+    prompt_label=f"enrich_{item.id[:8]}",
+    response_schema=ENRICH_SCHEMA, # override json_schema.schema
+    schema_name="enrich_item",     # override json_schema.name
+)
+```
+
+Comportement :
+- `response_schema=None` (défaut) → utilise `ITEMS_SCHEMA`, `_parse_response` exige la clé `items` (compat stricte Phase 3).
+- `response_schema` fourni → utilise le schema custom, `_parse_response` **n'exige PAS** la clé `items` (le caller inspecte `parsed_output` selon sa propre shape). La normalisation `warnings → list[str]` reste appliquée à toutes les shapes.
+
+Voir `scripts/enrichment.py:_ENRICH_RESPONSE_SCHEMA` pour le détail.
+
+### Skip rules
+
+- **Silencieux (pas de warning)** : items hébergés sur `x.com` ou `twitter.com` (tuple `ENRICH_X_HOSTS`) — la 1re passe a déjà produit un résumé à partir du `content` natif du post, un 2e appel serait redondant et la plupart du temps bloqué par x.com.
+- **Avec warning** : items avec `canonical_url` vide ou sans hostname parseable.
+
+### Dégradation gracieuse
+
+Un échec per-item n'interrompt JAMAIS l'enrichissement global :
+- `XAIError` (auth, rate limit, 5xx persistant, JSON invalide) → warning + item d'origine conservé ;
+- Timeout per-item (`future.result(timeout=20s)`) → warning + original ;
+- Deadline globale wall-clock dépassée (30s) → futures restants cancellés, originaux conservés avec warning ;
+- Summary vide / whitespace → warning + original.
+
+Les warnings sont agrégés dans `Briefing.warnings` (mais pas rendus dans le HTML — voir issue #20).
+
+### Logs structurés
+
+Chaque item enrichi émet une ligne JSON sur stderr, et un `enrichment_total` récapitulatif :
+
+```json
+{"event":"enrichment_call","prompt":"enrich_ab12cd34","status":"ok","item_id":"ab12cd34ef56","host":"lapresse.ca","summary_len":847,"tokens_in":1923,"tokens_out":412,"tool_calls":1,"cost_usd":0.0058,"duration_ms":4213}
+{"event":"enrichment_total","enriched_count":6,"skipped_count":4,"failed_count":1,"warnings_count":1,"tokens_in":11532,"tokens_out":2418,"tool_calls":6,"cost_usd":0.0335}
+```
+
+Captable via `python ... 2>&1 | jq 'select(.event | startswith("enrichment"))'`.
+
 ## Références
 
 - PRD §S1 (Sourcing), §S1.bis (Prompts), §Modes d'erreur, §Contraintes techniques
 - PLAN Phase 3
+- Issue #25 — Enrichissement 2e passe
 - Doc xAI : https://docs.x.ai/overview
 - Issue OpenClaw confirmant dépréciation Live Search : https://github.com/openclaw/openclaw/issues/26355

--- a/prompts/enrich.txt
+++ b/prompts/enrich.txt
@@ -1,0 +1,39 @@
+{# prompts/enrich.txt — 2e passe d'enrichissement (issue #25) #}
+{# Système inline : on NE dépend PAS de system.txt (dédié au sourcing multi-items). #}
+You are an enrichment agent for Christian's briefing (bilingual FR-QC reader, Quebec).
+
+Your ONLY task on this call: use the `web_search` tool to fetch the content of ONE specific URL,
+then return a single-item JSON object with a substantiated summary in Quebec French.
+
+# Input
+- URL        : {{ url }}
+- Title      : {{ title }}
+- Section    : {{ section_id }}
+
+# Instructions
+1. Call `web_search` (restricted by `allowed_domains` to the host of the URL) and fetch the article
+   body at `{{ url }}`. If the tool does not return the full page, do your best with the snippet.
+2. Produce a `summary` in **Quebec French**, **700-900 characters**, 5-8 phrases, substantiel et
+   factuel, style journalistique. Inclure : ce qui s'est passé, chiffres/noms clés, contexte utile,
+   et (1-2 mots) pourquoi ça compte pour un lecteur QC bilingue. NE PAS éditorialiser.
+3. Si le contenu est inaccessible, paywallé, ou hors sujet par rapport au titre, retourner un
+   `summary` vide (`""`) et un `warnings` explicatif ; le caller gardera le résumé d'origine.
+
+# OUTPUT (CRITICAL)
+
+Return **ONLY** a JSON object with this EXACT shape — single-item, NOT wrapped in `items`:
+
+```json
+{
+  "summary":  "<700-900 chars Quebec French, 5-8 phrases, substantiel et factuel>",
+  "warnings": ["<optional string>"]
+}
+```
+
+## DO NOT
+- **DO NOT** return a list, or a `{"items": [...]}` wrapper — just the single object above.
+- **DO NOT** add prose, markdown, or commentary outside the JSON object.
+- **DO NOT** translate the original title; only the `summary` is in Quebec French.
+- **DO NOT** fabricate numbers or quotes that aren't in the fetched content.
+
+Return JSON only.

--- a/scripts/build_briefing.py
+++ b/scripts/build_briefing.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from scripts.config import ConfigError, config_hash, load_config
 from scripts.dedup import dedupe
@@ -24,9 +24,17 @@ from scripts.select import (
 from scripts.window import briefing_id as compute_briefing_id
 from scripts.window import compute_window
 
+if TYPE_CHECKING:
+    from scripts.xai_client import XAIClient
+
 # Bumper en cas de modification sémantique des prompts dans prompts/.
 # Le hash est injecté en footer du HTML rendu (traçabilité audit).
-PROMPTS_VERSION = "prompts-v1.0"
+# v1.1 : ajout de prompts/enrich.txt (2e passe — issue #25).
+PROMPTS_VERSION = "prompts-v1.1"
+
+# Kill switch pour l'enrichissement 2e passe (issue #25).
+# Exporter `BRIEFING_ENRICH=0` pour désactiver. Défaut "1" = actif en mode live.
+_ENRICH_ENV_VAR = "BRIEFING_ENRICH"
 
 
 def _git_commit() -> str:
@@ -62,16 +70,14 @@ def _source_via_fixtures(
     return all_items, [], fixture_meta
 
 
-def _source_via_xai(
-    config: dict,
-    window_start: datetime,
-    window_end: datetime,
-) -> tuple[list[Item], list[str]]:
+def _make_xai_client() -> XAIClient:
     """
-    Charge des items via xAI Responses API (mode live, Phase 3).
-    Lazy import pour éviter dépendance httpx en mode fixture pur.
+    Instancie un `XAIClient` depuis l'env. Lazy import pour éviter la
+    dépendance httpx en mode fixture pur.
+
+    Le caller est responsable du `with client:` (context manager).
+    Lève `ConfigError` si `XAI_API_KEY` manque.
     """
-    from scripts.sourcing import source_briefing
     from scripts.xai_client import XAIClient
 
     api_key = os.environ.get("XAI_API_KEY")
@@ -84,8 +90,24 @@ def _source_via_xai(
     model = os.environ.get("XAI_MODEL", "grok-4-1-fast-non-reasoning")
     timeout_s = float(os.environ.get("XAI_TIMEOUT_S", "30"))
 
-    with XAIClient(api_key=api_key, model=model, timeout_s=timeout_s) as client:
-        result = source_briefing(client, config, window_start, window_end)
+    return XAIClient(api_key=api_key, model=model, timeout_s=timeout_s)
+
+
+def _source_via_xai(
+    client: XAIClient,
+    config: dict,
+    window_start: datetime,
+    window_end: datetime,
+) -> tuple[list[Item], list[str]]:
+    """
+    Charge des items via xAI Responses API (mode live, Phase 3).
+
+    Le `client` est passé par le caller (qui gère le context manager) pour
+    qu'il puisse être réutilisé par l'enrichissement 2e passe (issue #25).
+    """
+    from scripts.sourcing import source_briefing
+
+    result = source_briefing(client, config, window_start, window_end)
 
     sys.stderr.write(json.dumps({
         "event": "sourcing_total",
@@ -98,6 +120,30 @@ def _source_via_xai(
     }) + "\n")
 
     return result.items, result.warnings
+
+
+def _enrich_live(
+    client: XAIClient,
+    sections: dict[str, list[Item]],
+    dont_miss: Item | None,
+) -> tuple[dict[str, list[Item]], Item | None, list[str]]:
+    """
+    Appelle l'enrichissement 2e passe (issue #25).
+
+    Skippé silencieusement si `BRIEFING_ENRICH=0`. Retourne les sections
+    et `dont_miss` potentiellement enrichis, plus la liste des warnings.
+    """
+    if os.environ.get(_ENRICH_ENV_VAR, "1") == "0":
+        sys.stderr.write(json.dumps({
+            "event": "enrichment_skipped",
+            "reason": f"{_ENRICH_ENV_VAR}=0",
+        }) + "\n")
+        return sections, dont_miss, []
+
+    from scripts.enrichment import enrich_selected
+
+    result = enrich_selected(client, sections, dont_miss)
+    return result.sections, result.dont_miss, result.warnings
 
 
 def build(
@@ -113,28 +159,53 @@ def build(
     cfg_hash = config_hash(config_path)
 
     fixture_meta: dict | None = None
+    source_warnings: list[str]
+    enrich_warnings: list[str] = []
+
     if fixtures:
-        # Mode offline (Phase 1) — fixtures fournies
+        # Mode offline (Phase 1) — fixtures fournies, pas d'enrichissement
+        # (pas de vrai client xAI disponible).
         all_items, source_warnings, fixture_meta = _source_via_fixtures(fixtures)
+
+        now = _parse_now(now_override, fixture_meta)
+        window_start, window_end = compute_window(moment, now)  # type: ignore[arg-type]
+        bid = compute_briefing_id(moment, now)  # type: ignore[arg-type]
+
+        filtered = apply_engagement_filter(all_items, config["engagement_min"])
+        filtered = [it for it in filtered if window_start <= it.published_at <= window_end]
+        deduped = dedupe(filtered)
+
+        sections = select_by_section(deduped, sections_cfg)
+        dont_miss = select_dont_miss(deduped, sections)
     else:
-        # Mode live (Phase 3) — appels xAI réels
-        # On a besoin de la fenêtre AVANT le sourcing
+        # Mode live (Phase 3+Issue #25) — sourcing + enrichissement 2e passe,
+        # tous deux sous le même `XAIClient` (1 httpx.Client réutilisé).
         now_for_window = _parse_now(now_override, None)
         window_start_pre, window_end_pre = compute_window(moment, now_for_window)  # type: ignore[arg-type]
-        all_items, source_warnings = _source_via_xai(config, window_start_pre, window_end_pre)
 
-    now = _parse_now(now_override, fixture_meta)
-    window_start, window_end = compute_window(moment, now)  # type: ignore[arg-type]
-    bid = compute_briefing_id(moment, now)  # type: ignore[arg-type]
+        with _make_xai_client() as client:
+            all_items, source_warnings = _source_via_xai(
+                client, config, window_start_pre, window_end_pre,
+            )
 
-    filtered = apply_engagement_filter(all_items, config["engagement_min"])
-    filtered = [it for it in filtered if window_start <= it.published_at <= window_end]
-    deduped = dedupe(filtered)
+            now = _parse_now(now_override, None)
+            window_start, window_end = compute_window(moment, now)  # type: ignore[arg-type]
+            bid = compute_briefing_id(moment, now)  # type: ignore[arg-type]
 
-    sections = select_by_section(deduped, sections_cfg)
-    dont_miss = select_dont_miss(deduped, sections)
+            filtered = apply_engagement_filter(all_items, config["engagement_min"])
+            filtered = [it for it in filtered if window_start <= it.published_at <= window_end]
+            deduped = dedupe(filtered)
 
-    warnings: list[str] = list(source_warnings)
+            sections = select_by_section(deduped, sections_cfg)
+            dont_miss = select_dont_miss(deduped, sections)
+
+            # Enrichissement 2e passe (issue #25) : hooké ICI, après sélection,
+            # avant la construction du Briefing. Kill switch via BRIEFING_ENRICH=0.
+            sections, dont_miss, enrich_warnings = _enrich_live(
+                client, sections, dont_miss,
+            )
+
+    warnings: list[str] = list(source_warnings) + list(enrich_warnings)
     for sec in sections_cfg:
         if not sections.get(sec["id"]):
             warnings.append(f"section '{sec['id']}' vide")

--- a/scripts/enrichment.py
+++ b/scripts/enrichment.py
@@ -1,0 +1,487 @@
+"""
+Enrichissement 2e passe des items sélectionnés (issue #25).
+
+Hook point dans `scripts.build_briefing.build()` : APRES `select_by_section`
++ `select_dont_miss`, AVANT la construction du `Briefing`. Pour chaque item
+sélectionné (hors X/Twitter — redondant avec la 1re passe `x_search`) on
+appelle `web_search` restreint au domaine de l'URL pour obtenir un résumé
+substantiel (700-900 chars FR-QC).
+
+Conception :
+- Synchrone côté appel client, parallélisé via `ThreadPoolExecutor` (4 workers)
+  pour tenir le budget latence < 30s même sur 10-15 items enrichis.
+- Dégradation gracieuse : un échec par-item = warning + item d'origine conservé.
+  Jamais d'exception propagée au caller.
+- Deadline globale wall-clock (30s) : les futures en retard sont cancellées
+  et leurs items d'origine conservés avec un warning.
+- Schema JSON override : on passe `response_schema={summary, warnings}` à
+  `XAIClient.call()` qui accepte depuis issue #25 cette clé optionnelle.
+
+Voir `prompts/enrich.txt` pour le template, `docs/xai-integration.md#Enrichissement`
+pour la référence opérationnelle (coût, kill switch, etc).
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import dataclasses
+import json
+import logging
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from scripts.models import Item
+from scripts.xai_client import XAIClient, XAIError, XAIUsage
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constantes
+# ---------------------------------------------------------------------------
+
+DEFAULT_MAX_WORKERS = 4
+DEFAULT_PER_ITEM_TIMEOUT_S = 20.0
+GLOBAL_DEADLINE_S = 30.0
+
+# Hosts à skipper (redondant avec la 1re passe x_search).
+# On matche suffix (ex: "mobile.x.com" → skip, "foox.com" → NE PAS skip).
+ENRICH_X_HOSTS = ("x.com", "twitter.com")
+
+# Cap sur `raw_excerpt` — on stocke une copie brute du nouveau summary à des
+# fins d'audit/debug sans faire exploser la taille de l'Item.
+_RAW_EXCERPT_CAP = 2000
+
+# Cap minimal/maximal attendu sur le summary enrichi (informatif — le prompt
+# cible 700-900, on accepte 100-1500 pour tolérer les variations LLM).
+_MIN_SUMMARY_CHARS = 100
+_MAX_SUMMARY_CHARS = 1500
+
+# Nom du schema JSON pour le response_format override.
+_ENRICH_SCHEMA_NAME = "enrich_item"
+
+# Schema JSON single-item pour l'appel d'enrichissement.
+# Note : comme ITEMS_SCHEMA, on évite `format: uri` en strict (400 API).
+_ENRICH_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["summary", "warnings"],
+    "properties": {
+        "summary": {"type": "string", "minLength": 0, "maxLength": 2000},
+        "warnings": {
+            "type": "array",
+            "minItems": 0,
+            "items": {"type": "string"},
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Types de retour
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EnrichmentResult:
+    """Résultat agrégé de l'enrichissement 2e passe sur une sélection."""
+
+    sections: dict[str, list[Item]]
+    dont_miss: Item | None
+    warnings: list[str] = field(default_factory=list)
+    usage: XAIUsage = field(
+        default_factory=lambda: XAIUsage(input_tokens=0, output_tokens=0, tool_calls=0)
+    )
+    enriched_count: int = 0
+    skipped_count: int = 0
+
+
+# ---------------------------------------------------------------------------
+# API publique
+# ---------------------------------------------------------------------------
+
+
+def enrich_selected(
+    client: XAIClient,
+    sections: dict[str, list[Item]],
+    dont_miss: Item | None,
+    *,
+    prompts_dir: Path = Path("prompts"),
+    max_workers: int = DEFAULT_MAX_WORKERS,
+    timeout_s: float = DEFAULT_PER_ITEM_TIMEOUT_S,
+) -> EnrichmentResult:
+    """
+    Enrichit les items sélectionnés via un appel `web_search` par item.
+
+    Pour chaque item non skippé :
+      1. Restreint `allowed_domains` au hostname de `canonical_url` ;
+      2. Rend `prompts/enrich.txt` avec url/title/section_id ;
+      3. Appelle `client.call(..., response_schema=<single-item>)` ;
+      4. Remplace `summary` + `raw_excerpt` via `dataclasses.replace`.
+
+    Skip :
+      - hôtes `x.com` / `twitter.com` (silencieux, redondant avec 1re passe) ;
+      - URL vide ou sans hostname valide (avec warning).
+
+    Dégradation :
+      - XAIError per-item → warning, item d'origine conservé ;
+      - timeout per-item (future.result timeout) → warning + original ;
+      - deadline globale 30s dépassée → cancel, warning + original pour les
+        restants ;
+      - summary vide/whitespace → warning + original.
+
+    Args:
+        client: instance `XAIClient` partagée (1 httpx.Client pour toutes
+            les requêtes, thread-safe en lecture pour `post`).
+        sections: dict section_id → list[Item] issu de `select_by_section`.
+        dont_miss: Item (ou None) issu de `select_dont_miss`.
+        prompts_dir: dossier contenant `enrich.txt`.
+        max_workers: taille du pool (défaut 4).
+        timeout_s: timeout par futur (défaut 20s).
+
+    Returns:
+        `EnrichmentResult` avec `sections` et `dont_miss` enrichis (ou
+        d'origine sur skip/échec), `warnings`, `usage` agrégée, et
+        compteurs `enriched_count` / `skipped_count`.
+    """
+    deadline = time.monotonic() + GLOBAL_DEADLINE_S
+
+    env = _make_jinja_env(prompts_dir)
+    user_prompt_tmpl = env.get_template("enrich.txt")
+
+    # Collecte la liste plate d'items à traiter, en gardant un mapping
+    # vers leur emplacement (section_id, idx) ou ("__dont_miss__", 0).
+    Job = tuple[Item, str, int]  # (item, location_key, idx)
+    jobs: list[Job] = []
+    for section_id, items in sections.items():
+        for idx, item in enumerate(items):
+            jobs.append((item, section_id, idx))
+    if dont_miss is not None:
+        jobs.append((dont_miss, "__dont_miss__", 0))
+
+    # Partitionne en "à enrichir" vs "skip silencieux" (X/Twitter).
+    warnings: list[str] = []
+    to_enrich: list[Job] = []
+    skipped_silent = 0
+    for job in jobs:
+        item, _, _ = job
+        if _should_skip(item):
+            skipped_silent += 1
+            continue
+        host = _extract_host(item.canonical_url)
+        if not host:
+            warnings.append(
+                f"enrich[{item.id}]: invalid or empty canonical_url — skipped"
+            )
+            skipped_silent += 1
+            continue
+        to_enrich.append(job)
+
+    # Résultats : on part des originaux, on remplace au fur et à mesure.
+    enriched_by_location: dict[tuple[str, int], Item] = {}
+    total_usage = XAIUsage(input_tokens=0, output_tokens=0, tool_calls=0)
+    enriched_count = 0
+    failed_count = 0
+
+    if not to_enrich:
+        _log_total(
+            enriched_count=0,
+            skipped_count=skipped_silent,
+            failed_count=0,
+            usage=total_usage,
+            warnings_count=len(warnings),
+        )
+        return EnrichmentResult(
+            sections=sections,
+            dont_miss=dont_miss,
+            warnings=warnings,
+            usage=total_usage,
+            enriched_count=0,
+            skipped_count=skipped_silent,
+        )
+
+    # Dispatch parallèle. On utilise submit() + future → job pour relier
+    # chaque résultat à son emplacement et à son item d'origine.
+    workers = max(1, min(max_workers, len(to_enrich)))
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
+    future_to_job: dict[concurrent.futures.Future[tuple[Item | None, XAIUsage]], Job] = {}
+    try:
+        for job in to_enrich:
+            item, _, _ = job
+            future = executor.submit(
+                _enrich_one, client, item, user_prompt_tmpl,
+            )
+            future_to_job[future] = job
+
+        for future, job in future_to_job.items():
+            item, loc_key, idx = job
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                # Deadline globale atteinte avant même d'attendre ce futur.
+                future.cancel()
+                warnings.append(
+                    f"enrich[{item.id}]: global deadline ({GLOBAL_DEADLINE_S}s) "
+                    f"exceeded — keeping original"
+                )
+                failed_count += 1
+                continue
+
+            per_item_timeout = min(timeout_s, remaining)
+            try:
+                enriched_item, usage = future.result(timeout=per_item_timeout)
+            except concurrent.futures.TimeoutError:
+                future.cancel()
+                warnings.append(
+                    f"enrich[{item.id}]: timeout after {timeout_s}s — keeping original"
+                )
+                failed_count += 1
+                continue
+            except XAIError as exc:
+                # Normalement _enrich_one catche déjà les XAIError et retourne
+                # None — mais on se protège d'une fuite éventuelle.
+                warnings.append(
+                    f"enrich[{item.id}]: {type(exc).__name__}: {exc} — keeping original"
+                )
+                failed_count += 1
+                continue
+            except Exception as exc:
+                # Garde-fou absolu : un worker ne doit jamais tuer l'enrichissement
+                # global. On capte tout (ValueError, RuntimeError, etc.) et on
+                # conserve l'item d'origine avec un warning explicite.
+                warnings.append(
+                    f"enrich[{item.id}]: unexpected {type(exc).__name__}: {exc} "
+                    f"— keeping original"
+                )
+                failed_count += 1
+                continue
+
+            total_usage = _add_usage(total_usage, usage)
+
+            if enriched_item is None:
+                # _enrich_one a logué un warning structuré et renvoie None
+                # pour signaler un échec "soft" (XAIError, summary vide, etc).
+                warnings.append(
+                    f"enrich[{item.id}]: enrichment returned no summary "
+                    f"— keeping original"
+                )
+                failed_count += 1
+                continue
+
+            enriched_by_location[(loc_key, idx)] = enriched_item
+            enriched_count += 1
+    finally:
+        # Ne pas bloquer sur les futures restantes — on a déjà cancellé
+        # celles qui dépassent la deadline. `wait=False` évite de
+        # sérialiser les appels réseau en vol encore.
+        executor.shutdown(wait=False, cancel_futures=True)
+
+    # Reconstruction des sections avec les items enrichis substitués.
+    new_sections: dict[str, list[Item]] = {
+        sid: list(items) for sid, items in sections.items()
+    }
+    new_dont_miss = dont_miss
+    for (loc_key, idx), enriched_item in enriched_by_location.items():
+        if loc_key == "__dont_miss__":
+            new_dont_miss = enriched_item
+        else:
+            new_sections[loc_key][idx] = enriched_item
+
+    skipped_count = skipped_silent + failed_count
+    _log_total(
+        enriched_count=enriched_count,
+        skipped_count=skipped_count,
+        failed_count=failed_count,
+        usage=total_usage,
+        warnings_count=len(warnings),
+    )
+
+    return EnrichmentResult(
+        sections=new_sections,
+        dont_miss=new_dont_miss,
+        warnings=warnings,
+        usage=total_usage,
+        enriched_count=enriched_count,
+        skipped_count=skipped_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _should_skip(item: Item) -> bool:
+    """
+    Retourne True si l'item doit être skippé silencieusement (pas de warning).
+
+    On skippe tout ce qui est hébergé sur `x.com` ou `twitter.com` : la 1re
+    passe `x_search` a déjà produit un résumé à partir du `content` du post
+    — un 2e appel `web_search` sur la même URL serait redondant et coûteux
+    (et x.com bloque le plus souvent le scraping).
+    """
+    host = _extract_host(item.canonical_url)
+    if not host:
+        return False  # laisse le caller signaler via warning
+    return any(host == h or host.endswith("." + h) for h in ENRICH_X_HOSTS)
+
+
+def _extract_host(url: str) -> str:
+    """Extrait le hostname (sans `www.`) d'une URL ; '' si invalide/vide."""
+    if not url or not isinstance(url, str):
+        return ""
+    try:
+        parsed = urlparse(url)
+    except (ValueError, TypeError):
+        return ""
+    host = (parsed.hostname or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host
+
+
+def _make_jinja_env(prompts_dir: Path) -> Environment:
+    """Env Jinja2 isolé (StrictUndefined, cohérent avec sourcing.py)."""
+    return Environment(
+        loader=FileSystemLoader(str(prompts_dir)),
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+        autoescape=False,
+    )
+
+
+def _enrich_one(
+    client: XAIClient,
+    item: Item,
+    user_prompt_tmpl: Any,  # jinja2.Template — typé Any pour éviter l'import
+) -> tuple[Item | None, XAIUsage]:
+    """
+    Enrichit UN item via `web_search` restreint au domaine.
+
+    Retourne :
+      - `(enriched_item, usage)` en cas de succès ;
+      - `(None, zero_usage)` en cas d'échec soft non-exceptionnel (summary vide
+        ou invalide) ; le caller ajoutera un warning générique.
+
+    **Laisse remonter `XAIError`** au caller pour que le warning inclue le
+    nom exact de l'exception (observability — issue #25 test coverage).
+    """
+    zero_usage = XAIUsage(input_tokens=0, output_tokens=0, tool_calls=0)
+    host = _extract_host(item.canonical_url)
+    if not host:
+        # Déjà filtré en amont, mais garde-fou défensif.
+        return None, zero_usage
+
+    prompt_label = f"enrich_{item.id[:8]}"
+
+    # Système inline dans enrich.txt (pas de system.txt ici — sémantique
+    # différente : single-item vs multi-items).
+    user_prompt = user_prompt_tmpl.render(
+        url=item.canonical_url,
+        title=item.title,
+        section_id=item.section_id,
+    )
+
+    tool_params = {"allowed_domains": [host]}
+
+    # TODO(live): valider que `allowed_domains` accepte la forme `["host"]`
+    # pour `web_search` et que le retour du tool contient bien le body de
+    # l'article (et non juste un snippet SERP). Fallback : summary d'origine.
+    response = client.call(
+        system_prompt="",  # le prompt de rôle est inclus dans enrich.txt
+        user_prompt=user_prompt,
+        tool="web_search",
+        tool_params=tool_params,
+        prompt_label=prompt_label,
+        response_schema=_ENRICH_RESPONSE_SCHEMA,
+        schema_name=_ENRICH_SCHEMA_NAME,
+    )
+
+    parsed = response.parsed_output
+    new_summary_raw = parsed.get("summary") if isinstance(parsed, dict) else None
+    new_summary = str(new_summary_raw or "").strip()
+
+    if not new_summary:
+        _log_enrich_skip(prompt_label, item.id, reason="empty_summary")
+        return None, response.usage
+
+    # Log structuré de succès (mirroir de xai_client._log_call).
+    _log_enrich_ok(
+        prompt_label,
+        item_id=item.id,
+        host=host,
+        summary_len=len(new_summary),
+        tokens_in=response.usage.input_tokens,
+        tokens_out=response.usage.output_tokens,
+        tool_calls=response.usage.tool_calls,
+        cost_usd=round(response.usage.cost_usd, 4),
+        duration_ms=response.duration_ms,
+    )
+
+    enriched = dataclasses.replace(
+        item,
+        summary=new_summary,
+        raw_excerpt=new_summary[:_RAW_EXCERPT_CAP],
+    )
+    return enriched, response.usage
+
+
+def _add_usage(a: XAIUsage, b: XAIUsage) -> XAIUsage:
+    """Somme deux XAIUsage (même pattern que sourcing._add_usage)."""
+    return XAIUsage(
+        input_tokens=a.input_tokens + b.input_tokens,
+        output_tokens=a.output_tokens + b.output_tokens,
+        tool_calls=a.tool_calls + b.tool_calls,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Logs structurés (stderr JSON, parseable via jq)
+# ---------------------------------------------------------------------------
+
+
+def _log_enrich_ok(prompt_label: str, **fields: Any) -> None:
+    record = {
+        "event": "enrichment_call",
+        "prompt": prompt_label,
+        "status": "ok",
+        **fields,
+    }
+    print(json.dumps(record, ensure_ascii=False), file=sys.stderr)
+
+
+def _log_enrich_skip(prompt_label: str, item_id: str, *, reason: str) -> None:
+    record = {
+        "event": "enrichment_call",
+        "prompt": prompt_label,
+        "status": "skipped",
+        "item_id": item_id,
+        "reason": reason,
+    }
+    print(json.dumps(record, ensure_ascii=False), file=sys.stderr)
+
+
+def _log_total(
+    *,
+    enriched_count: int,
+    skipped_count: int,
+    failed_count: int,
+    usage: XAIUsage,
+    warnings_count: int,
+) -> None:
+    record = {
+        "event": "enrichment_total",
+        "enriched_count": enriched_count,
+        "skipped_count": skipped_count,
+        "failed_count": failed_count,
+        "warnings_count": warnings_count,
+        "tokens_in": usage.input_tokens,
+        "tokens_out": usage.output_tokens,
+        "tool_calls": usage.tool_calls,
+        "cost_usd": round(usage.cost_usd, 4),
+    }
+    print(json.dumps(record, ensure_ascii=False), file=sys.stderr)

--- a/scripts/xai_client.py
+++ b/scripts/xai_client.py
@@ -209,6 +209,8 @@ class XAIClient:
         tool: Literal["x_search", "web_search"],
         tool_params: dict[str, Any] | None = None,
         prompt_label: str = "unspecified",
+        response_schema: dict[str, Any] | None = None,
+        schema_name: str = "briefing_items",
     ) -> XAIResponse:
         """
         Effectue UN appel à /v1/responses avec un seul tool, et retourne
@@ -222,8 +224,21 @@ class XAIClient:
           le budget de retry général)
         - JSON invalide : 1 retry max (compteur séparé)
         - Total max : ~30s + ~14s + 60s = ~104s, sous le budget 180s du PRD §S3
+
+        Args:
+            response_schema: schema JSON custom à utiliser à la place de
+                ITEMS_SCHEMA (issue #25 — enrichment call). Si None, comportement
+                strictement identique à la V1 (sourcing multi-items). Quand fourni,
+                le caller doit gérer sa propre shape de réponse (ex: enrichment
+                attend `{summary, warnings}` single-item) — `_parse_response` ne
+                validera PAS la présence d'`items` dans ce cas.
+            schema_name: nom du schema (injecté en `response_format.json_schema.name`).
+                Laissé à "briefing_items" par défaut pour compat arrière.
         """
-        body = self._build_body(system_prompt, user_prompt, tool, tool_params)
+        body = self._build_body(
+            system_prompt, user_prompt, tool, tool_params,
+            response_schema=response_schema, schema_name=schema_name,
+        )
 
         attempt = 0          # 5xx / timeout / network
         attempt_429 = 0      # rate limit (séparé)
@@ -295,7 +310,7 @@ class XAIClient:
 
             # 2xx — parser la réponse
             try:
-                parsed = self._parse_response(resp.json())
+                parsed = self._parse_response(resp.json(), schema_name=schema_name)
             except (json.JSONDecodeError, KeyError, ValueError) as e:
                 attempt_invalid += 1
                 self._log_call(
@@ -332,6 +347,9 @@ class XAIClient:
         user_prompt: str,
         tool: str,
         tool_params: dict[str, Any] | None,
+        *,
+        response_schema: dict[str, Any] | None = None,
+        schema_name: str = "briefing_items",
     ) -> dict[str, Any]:
         # Validation tool_params (review CRITICAL #3) : refus de toute clé
         # inconnue ou conflictuelle avec `type`.
@@ -348,6 +366,8 @@ class XAIClient:
                 "tool_params must not contain 'type' (set via positional arg)"
             )
 
+        schema = response_schema if response_schema is not None else ITEMS_SCHEMA
+
         return {
             "model": self.model,
             "input": [
@@ -358,16 +378,18 @@ class XAIClient:
             "response_format": {
                 "type": "json_schema",
                 "json_schema": {
-                    "name": "briefing_items",
+                    "name": schema_name,
                     "strict": True,
-                    "schema": ITEMS_SCHEMA,
+                    "schema": schema,
                 },
             },
         }
 
-    def _parse_response(self, raw: dict[str, Any]) -> dict[str, Any]:
+    def _parse_response(
+        self, raw: dict[str, Any], *, schema_name: str = "briefing_items",
+    ) -> dict[str, Any]:
         """
-        Extrait `model`, l'output texte (JSON conforme à ITEMS_SCHEMA), et l'usage.
+        Extrait `model`, l'output texte (JSON), et l'usage.
 
         TODO(live): valider la forme exacte au premier appel réel.
         Forme actuelle assumée :
@@ -376,32 +398,50 @@ class XAIClient:
             "output": [{type:message, content:[{type:output_text, text:"<json>"}]}],
             "usage": {input_tokens, output_tokens, tool_calls}
           }
+
+        Politique de validation (issue #25) :
+        - `schema_name == "briefing_items"` (défaut, sourcing) : on exige la
+          présence de la clé `items`. Tolérance live (issue #15) : si le LLM
+          renvoie un array nu, on le wrap en `{"items": [...], "warnings": []}`.
+        - `schema_name` custom (ex: enrichment, single-item) : on ne valide PAS
+          `items`. On normalise seulement `warnings` si la clé existe. Le caller
+          inspecte `parsed_output` selon sa propre shape.
         """
         model = raw.get("model", self.model)
+        is_briefing_items = schema_name == "briefing_items"
 
         # Extraction défensive du output_text final
         output_text = self._extract_output_text(raw)
         parsed = json.loads(output_text)
 
-        # Fix live (issue #15) : l'API retourne souvent un array JSON nu
-        # `[{...}, {...}]` au lieu de `{"items": [...], "warnings": [...]}`,
-        # malgré `response_format: json_schema strict`. On tolère les deux formes.
+        # Fix live (issue #15) : pour le sourcing l'API retourne souvent un
+        # array JSON nu `[{...}, {...}]` au lieu de `{"items": [...], "warnings": []}`
+        # malgré `response_format: json_schema strict`. On tolère pour briefing_items.
+        # Pour les schemas custom (enrichment single-item), un array top-level serait
+        # invalide — on propage l'erreur.
         if isinstance(parsed, list):
-            parsed = {"items": parsed, "warnings": []}
+            if is_briefing_items:
+                parsed = {"items": parsed, "warnings": []}
+            else:
+                raise ValueError(
+                    f"parsed output is a list but schema '{schema_name}' expects an object"
+                )
         elif not isinstance(parsed, dict):
             raise ValueError(
                 f"parsed output is neither list nor dict, got {type(parsed).__name__}"
             )
 
-        # Validation minimale de la structure (pour les cas pathologiques)
-        if "items" not in parsed:
+        # Validation minimale de la structure (pour les cas pathologiques).
+        # Appliquée uniquement en sourcing (schema briefing_items) — les schemas
+        # custom (ex: enrichment) n'ont pas de clé `items`.
+        if is_briefing_items and "items" not in parsed:
             raise ValueError(
                 f"missing 'items' in parsed output: {list(parsed.keys())}"
             )
 
         # Normalisation warnings (issue #17) : le LLM peut renvoyer une string
         # unique ou autre chose. On force list[str] pour éviter l'itération
-        # char-par-char côté caller.
+        # char-par-char côté caller. Appliqué pour toutes les shapes (si présent).
         raw_warnings = parsed.get("warnings")
         if isinstance(raw_warnings, str):
             parsed["warnings"] = [raw_warnings]

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -1,0 +1,614 @@
+"""Tests du 2e passage d'enrichissement (issue #25).
+
+Le module `scripts.enrichment` exécute un appel xAI `web_search` par item
+(skippe X posts et URLs invalides), merge le résumé / raw_excerpt et
+aggrège usage + warnings. Voir `enrich_selected` pour le contrat exact.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.enrichment import EnrichmentResult, enrich_selected
+from scripts.models import Item
+from scripts.xai_client import XAIError, XAIResponse, XAIUnavailable, XAIUsage
+
+PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _enriched_response(
+    summary: str = "Synthèse enrichie de plus de 800 caractères détaillant le contexte.",
+    warnings: list[str] | None = None,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    tool_calls: int = 1,
+) -> XAIResponse:
+    return XAIResponse(
+        parsed_output={"summary": summary, "warnings": warnings or []},
+        usage=XAIUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            tool_calls=tool_calls,
+        ),
+        duration_ms=500,
+        model="grok-stub",
+    )
+
+
+class StubClient:
+    """Stub XAIClient. Enregistre les appels et retourne des réponses scriptées.
+
+    Responses peut être :
+    - une list[XAIResponse | Exception] (index-based)
+    - un callable(idx, record) -> XAIResponse | Exception
+    - un dict[str, XAIResponse | Exception] keyé par un substring du prompt_label
+    """
+
+    def __init__(self, responses_or_factory: Any):
+        self._responses = responses_or_factory
+        self.calls: list[dict[str, Any]] = []
+        self.model = "stub"
+
+    def call(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        *,
+        tool: str,
+        tool_params: dict[str, Any] | None = None,
+        prompt_label: str = "unspecified",
+        response_schema: dict[str, Any] | None = None,
+        schema_name: str = "briefing_items",
+    ) -> XAIResponse:
+        record = {
+            "system_prompt": system_prompt,
+            "user_prompt": user_prompt,
+            "tool": tool,
+            "tool_params": tool_params,
+            "prompt_label": prompt_label,
+            "response_schema": response_schema,
+            "schema_name": schema_name,
+        }
+        self.calls.append(record)
+        idx = len(self.calls) - 1
+
+        if isinstance(self._responses, dict):
+            value: Any = None
+            for key, resp in self._responses.items():
+                if key in prompt_label:
+                    value = resp
+                    break
+            if value is None:
+                value = _enriched_response()
+        elif callable(self._responses):
+            value = self._responses(idx, record)
+        else:
+            value = (
+                self._responses[idx]
+                if idx < len(self._responses)
+                else _enriched_response()
+            )
+
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def make_item_factory() -> Callable[..., Item]:
+    """Factory d'Item sans dépendre de la conftest fixture pour varier l'URL."""
+
+    def _make(
+        item_id: str = "abc123def456",
+        title: str = "Titre initial",
+        summary: str = "Résumé initial court.",
+        url: str = "https://lapresse.ca/foo",
+        section_id: str = "ai-tech",
+        source_type: str = "web",
+        source_handle: str = "lapresse.ca",
+        published_at: datetime | None = None,
+        score: float = 0.85,
+        likes: int = 0,
+        reposts: int = 0,
+        short_url: str = "https://short.ex/abc",
+        raw_excerpt: str = "",
+        alt_sources: tuple[str, ...] = (),
+    ) -> Item:
+        return Item(
+            id=item_id,
+            title=title,
+            summary=summary,
+            canonical_url=url,
+            section_id=section_id,
+            source_type=source_type,  # type: ignore[arg-type]
+            source_handle=source_handle,
+            published_at=published_at
+            or datetime(2026, 4, 19, 3, 0, 0, tzinfo=UTC),
+            score=score,
+            short_url=short_url,
+            raw_excerpt=raw_excerpt,
+            alt_sources=alt_sources,
+            likes=likes,
+            reposts=reposts,
+        )
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_returns_enrichment_result_dataclass() -> None:
+    client = StubClient(lambda i, r: _enriched_response())
+    result = enrich_selected(
+        client=client,
+        sections={},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+    assert isinstance(result, EnrichmentResult)
+    assert result.sections == {}
+    assert result.dont_miss is None
+    assert result.warnings == []
+    assert isinstance(result.usage, XAIUsage)
+    assert result.enriched_count == 0
+    assert result.skipped_count == 0
+
+
+def test_enriches_web_item_happy_path(make_item_factory) -> None:
+    original = make_item_factory(url="https://lapresse.ca/foo")
+    new_summary = "Synthèse enrichie détaillée avec contexte et chiffres-clés."
+    client = StubClient([_enriched_response(summary=new_summary)])
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [original]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    assert result.enriched_count == 1
+    enriched = result.sections["ai-tech"][0]
+    assert enriched.summary == new_summary
+    assert enriched.raw_excerpt  # non-empty, populated from enrichment
+    # Other fields preserved
+    assert enriched.title == original.title
+    assert enriched.canonical_url == original.canonical_url
+    assert enriched.section_id == original.section_id
+    assert enriched.score == original.score
+    assert enriched.likes == original.likes
+    assert enriched.reposts == original.reposts
+    assert enriched.published_at == original.published_at
+
+
+def test_enriches_dont_miss(make_item_factory) -> None:
+    dm = make_item_factory(
+        item_id="dontmiss1", url="https://lapresse.ca/important",
+    )
+    new_summary = "Synthèse enrichie du don't-miss."
+    client = StubClient([_enriched_response(summary=new_summary)])
+
+    result = enrich_selected(
+        client=client,
+        sections={},
+        dont_miss=dm,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    assert result.dont_miss is not None
+    assert result.dont_miss.summary == new_summary
+    assert result.enriched_count == 1
+
+
+def test_dont_miss_none_handled(make_item_factory) -> None:
+    item = make_item_factory()
+    client = StubClient([_enriched_response()])
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [item]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    assert result.dont_miss is None
+    assert result.enriched_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Skip behaviors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://x.com/karpathy/status/1",
+        "https://twitter.com/karpathy/status/1",
+        "https://www.x.com/user/status/42",
+        "https://mobile.twitter.com/user/status/42",
+    ],
+)
+def test_skips_x_com_items(make_item_factory, url: str) -> None:
+    item = make_item_factory(url=url)
+    client = StubClient(lambda i, r: pytest.fail("must not call xAI for X posts"))
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [item]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    returned = result.sections["ai-tech"][0]
+    # Identity check on summary — original unchanged
+    assert returned.summary == item.summary
+    assert len(client.calls) == 0
+    assert result.skipped_count == 1
+    assert result.warnings == []  # no warning for X posts
+
+
+@pytest.mark.parametrize("bad_url", ["", "not-a-url", "   "])
+def test_skips_invalid_url_with_warning(make_item_factory, bad_url: str) -> None:
+    item = make_item_factory(url=bad_url)
+    client = StubClient(lambda i, r: pytest.fail("must not call for invalid URL"))
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [item]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    assert result.sections["ai-tech"][0].summary == item.summary
+    assert result.skipped_count == 1
+    assert len(result.warnings) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tool params / schema on client.call
+# ---------------------------------------------------------------------------
+
+
+def test_tool_params_contains_allowed_domains(make_item_factory) -> None:
+    item = make_item_factory(url="https://www.journaldequebec.com/article/123")
+    client = StubClient([_enriched_response()])
+
+    enrich_selected(
+        client=client,
+        sections={"ai-tech": [item]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    assert len(client.calls) == 1
+    tool_params = client.calls[0]["tool_params"]
+    assert tool_params is not None
+    assert tool_params["allowed_domains"] == ["journaldequebec.com"]
+
+
+def test_tool_equals_web_search(make_item_factory) -> None:
+    item = make_item_factory(url="https://lapresse.ca/foo")
+    client = StubClient([_enriched_response()])
+
+    enrich_selected(
+        client=client,
+        sections={"ai-tech": [item]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    assert client.calls[0]["tool"] == "web_search"
+
+
+def test_response_schema_custom_for_enrichment(make_item_factory) -> None:
+    item = make_item_factory(url="https://lapresse.ca/foo")
+    client = StubClient([_enriched_response()])
+
+    enrich_selected(
+        client=client,
+        sections={"ai-tech": [item]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    call = client.calls[0]
+    assert call["response_schema"] is not None
+    assert call["schema_name"] != "briefing_items"
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation — per-item isolation
+# ---------------------------------------------------------------------------
+
+
+def test_single_item_failure_isolated(make_item_factory) -> None:
+    item_a = make_item_factory(item_id="aaaaaaaa1111", url="https://lapresse.ca/a")
+    item_b = make_item_factory(item_id="bbbbbbbb2222", url="https://lapresse.ca/b")
+    item_c = make_item_factory(item_id="cccccccc3333", url="https://lapresse.ca/c")
+
+    def factory(idx: int, rec: dict[str, Any]) -> Any:
+        # The middle item (item_b) fails. We detect it via the id prefix appearing
+        # in the prompt_label or user_prompt. Fall back to checking user_prompt.
+        label = rec.get("prompt_label", "")
+        user_prompt = rec.get("user_prompt", "")
+        if item_b.id[:8] in label or item_b.id[:8] in user_prompt or "lapresse.ca/b" in user_prompt:
+            return XAIUnavailable("xAI down for b")
+        return _enriched_response(summary=f"enriched {idx}")
+
+    client = StubClient(factory)
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [item_a, item_b, item_c]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    out = result.sections["ai-tech"]
+    assert len(out) == 3
+    # item_b kept original
+    kept = next(i for i in out if i.id == item_b.id)
+    assert kept.summary == item_b.summary
+    # item_a and item_c enriched
+    for it in out:
+        if it.id in (item_a.id, item_c.id):
+            assert it.summary.startswith("enriched")
+    assert result.enriched_count == 2
+    # Warning mentions failing item + XAIUnavailable
+    assert any(
+        "XAIUnavailable" in w and item_b.id in w for w in result.warnings
+    )
+
+
+def test_all_items_fail_returns_originals_with_warning(make_item_factory) -> None:
+    item_a = make_item_factory(item_id="aaaa1111", url="https://lapresse.ca/a")
+    item_b = make_item_factory(item_id="bbbb2222", url="https://lapresse.ca/b")
+
+    client = StubClient(lambda i, r: XAIError("boom"))
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [item_a, item_b]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    out = result.sections["ai-tech"]
+    assert len(out) == 2
+    assert out[0].summary == item_a.summary
+    assert out[1].summary == item_b.summary
+    assert result.enriched_count == 0
+    assert len(result.warnings) >= 1  # at least one warning (1 per item ideal)
+
+
+# ---------------------------------------------------------------------------
+# Timeout behavior
+# ---------------------------------------------------------------------------
+
+
+def test_per_item_timeout(make_item_factory) -> None:
+    item = make_item_factory(url="https://lapresse.ca/slow")
+
+    class SlowClient:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+            self.model = "slow-stub"
+
+        def call(self, *args: Any, **kwargs: Any) -> XAIResponse:
+            self.calls.append({"args": args, "kwargs": kwargs})
+            time.sleep(2.0)  # longer than timeout_s=0.5
+            return _enriched_response()
+
+    client = SlowClient()
+
+    t0 = time.monotonic()
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [item]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+        timeout_s=0.5,
+    )
+    elapsed = time.monotonic() - t0
+
+    # (a) total time bounded
+    assert elapsed < 3.0
+    # (b) original preserved
+    assert result.sections["ai-tech"][0].summary == item.summary
+    # (c) warning mentions timeout
+    assert any("timeout" in w.lower() for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Content validation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_summary_from_llm_kept_original(make_item_factory) -> None:
+    item = make_item_factory(url="https://lapresse.ca/foo")
+    client = StubClient([_enriched_response(summary="")])
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [item]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    assert result.sections["ai-tech"][0].summary == item.summary
+    assert len(result.warnings) >= 1
+
+
+def test_whitespace_only_summary_kept_original(make_item_factory) -> None:
+    item = make_item_factory(url="https://lapresse.ca/foo")
+    client = StubClient([_enriched_response(summary="   \n\t  ")])
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [item]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    assert result.sections["ai-tech"][0].summary == item.summary
+    assert len(result.warnings) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Ordering / immutability
+# ---------------------------------------------------------------------------
+
+
+def test_order_preserved_within_section(make_item_factory) -> None:
+    items = [
+        make_item_factory(
+            item_id=f"id{i:08d}", url=f"https://lapresse.ca/article-{i}"
+        )
+        for i in range(3)
+    ]
+
+    # Return different summaries with slightly randomized sleep to force
+    # thread scheduling to scramble completion order.
+    def factory(idx: int, rec: dict[str, Any]) -> XAIResponse:
+        # Reverse sleep duration so later submits complete first
+        time.sleep(0.01 * (3 - idx))
+        return _enriched_response(summary=f"enriched-{idx}")
+
+    client = StubClient(factory)
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": items},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    out = result.sections["ai-tech"]
+    assert [it.id for it in out] == [it.id for it in items]
+
+
+def test_other_fields_preserved_after_enrichment(make_item_factory) -> None:
+    original = make_item_factory(
+        item_id="xyz12345",
+        title="Titre original",
+        url="https://lapresse.ca/detail",
+        section_id="ai-tech",
+        source_type="web",
+        source_handle="lapresse.ca",
+        score=0.77,
+        likes=123,
+        reposts=45,
+        short_url="https://short.ex/orig",
+        alt_sources=("https://alt1.com", "https://alt2.com"),
+    )
+    client = StubClient([_enriched_response(summary="nouveau résumé")])
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [original]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    out = result.sections["ai-tech"][0]
+    assert out.title == original.title
+    assert out.canonical_url == original.canonical_url
+    assert out.section_id == original.section_id
+    assert out.score == original.score
+    assert out.likes == original.likes
+    assert out.reposts == original.reposts
+    assert out.published_at == original.published_at
+    assert out.source_type == original.source_type
+    assert out.source_handle == original.source_handle
+    assert out.short_url == original.short_url
+    assert out.alt_sources == original.alt_sources
+
+
+# ---------------------------------------------------------------------------
+# Usage aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_usage_aggregated_across_calls(make_item_factory) -> None:
+    items = [
+        make_item_factory(item_id=f"id{i:08d}", url=f"https://lapresse.ca/{i}")
+        for i in range(3)
+    ]
+    client = StubClient(
+        lambda i, r: _enriched_response(
+            summary=f"s-{i}", input_tokens=100, output_tokens=50, tool_calls=1
+        )
+    )
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": items},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    assert result.usage.input_tokens == 300
+    assert result.usage.output_tokens == 150
+    assert result.usage.tool_calls == 3
+
+
+def test_enriched_count_and_skipped_count(make_item_factory) -> None:
+    web1 = make_item_factory(item_id="web00001", url="https://lapresse.ca/a")
+    web2 = make_item_factory(item_id="web00002", url="https://lesaffaires.com/b")
+    x_post = make_item_factory(
+        item_id="xpost001",
+        url="https://x.com/u/status/1",
+        source_type="x_account",
+        source_handle="@u",
+    )
+    invalid = make_item_factory(item_id="inv00001", url="")
+
+    client = StubClient(lambda i, r: _enriched_response(summary=f"ok-{i}"))
+
+    result = enrich_selected(
+        client=client,
+        sections={"ai-tech": [web1, web2, x_post, invalid]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    assert result.enriched_count == 2
+    assert result.skipped_count == 2
+
+
+def test_frozen_item_not_mutated(make_item_factory) -> None:
+    original = make_item_factory(url="https://lapresse.ca/foo", summary="ORIG")
+    snapshot = replace(original)  # detached copy via dataclass replace
+
+    client = StubClient([_enriched_response(summary="nouveau")])
+
+    enrich_selected(
+        client=client,
+        sections={"ai-tech": [original]},
+        dont_miss=None,
+        prompts_dir=PROMPTS_DIR,
+    )
+
+    # Frozen dataclass : original must still have "ORIG"
+    assert original.summary == "ORIG"
+    assert original.summary == snapshot.summary

--- a/tests/test_xai_client.py
+++ b/tests/test_xai_client.py
@@ -630,3 +630,98 @@ def test_warnings_list_of_non_strings_coerced_to_str(
 
     resp = client.call("s", "u", tool="x_search")
     assert resp.parsed_output["warnings"] == ["ok", "42", "None"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #25 : response_schema / schema_name overrides for enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_call_default_schema_is_briefing_items(
+    client: XAIClient, httpx_mock: HTTPXMock
+) -> None:
+    """Without the new params, body sent to xAI contains
+    response_format.json_schema.name == "briefing_items" AND the current
+    ITEMS_SCHEMA."""
+    httpx_mock.add_response(url=XAI_URL, json=_ok_payload())
+    client.call("sys", "user", tool="x_search")
+
+    body = json.loads(httpx_mock.get_requests()[0].content)
+    json_schema = body["response_format"]["json_schema"]
+    assert json_schema["name"] == "briefing_items"
+    assert json_schema["schema"] == ITEMS_SCHEMA
+
+
+def test_call_custom_schema_overrides_default(
+    client: XAIClient, httpx_mock: HTTPXMock
+) -> None:
+    """When response_schema + schema_name are passed, the body carries those
+    values instead of ITEMS_SCHEMA / briefing_items."""
+    custom_schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["summary", "warnings"],
+        "properties": {
+            "summary": {"type": "string", "minLength": 0, "maxLength": 2000},
+            "warnings": {
+                "type": "array",
+                "minItems": 0,
+                "items": {"type": "string"},
+            },
+        },
+    }
+    # The handler returns {"summary": "...", "warnings": []} shaped payload
+    inner = json.dumps({"summary": "enriched content", "warnings": []})
+    payload = {
+        "model": "grok",
+        "output_text": inner,
+        "usage": {"input_tokens": 10, "output_tokens": 5, "tool_calls": 1},
+    }
+    httpx_mock.add_response(url=XAI_URL, json=payload)
+
+    client.call(
+        "sys", "user",
+        tool="web_search",
+        tool_params={"allowed_domains": ["example.com"]},
+        response_schema=custom_schema,
+        schema_name="enrichment",
+    )
+
+    body = json.loads(httpx_mock.get_requests()[0].content)
+    json_schema = body["response_format"]["json_schema"]
+    assert json_schema["name"] == "enrichment"
+    assert json_schema["schema"] == custom_schema
+
+
+def test_call_custom_schema_no_items_key_not_enforced(
+    client: XAIClient, httpx_mock: HTTPXMock
+) -> None:
+    """With a custom schema, the LLM may return {"summary": "x"} (no "items"
+    key) and parsing must NOT raise XAIInvalidResponse — the items-presence
+    check only applies for the default briefing_items schema."""
+    custom_schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["summary"],
+        "properties": {
+            "summary": {"type": "string"},
+        },
+    }
+    inner = json.dumps({"summary": "x"})  # no "items" key, no "warnings"
+    payload = {
+        "model": "grok",
+        "output_text": inner,
+        "usage": {"input_tokens": 1, "output_tokens": 1, "tool_calls": 0},
+    }
+    httpx_mock.add_response(url=XAI_URL, json=payload)
+
+    resp = client.call(
+        "sys", "user",
+        tool="web_search",
+        tool_params={"allowed_domains": ["example.com"]},
+        response_schema=custom_schema,
+        schema_name="enrichment",
+    )
+    assert resp.parsed_output["summary"] == "x"
+    # warnings normalized to [] when absent
+    assert resp.parsed_output["warnings"] == []


### PR DESCRIPTION
Closes #25.

## Architecture (multi-agents)

Conçu + codé via 3 agents spécialisés :
1. **Plan agent** — design architecture (concurrence, error handling, hooks, signatures) → 6 décisions figées
2. **Impl agent** (general-purpose) — code production
3. **Tests agent** (general-purpose) — tests comprehensive en parallèle

Un bug côté impl (XAIError swallowed silencieusement dans `_enrich_one`) identifié via le test `test_single_item_failure_isolated` qui échouait → fix appliqué manuellement (laisser remonter au caller pour préserver le nom de l'exception dans le warning).

## Scope

Après sourcing + dedup + selection, on a ~14 items candidats. Pour chaque item avec URL non-X, on fait un **2e appel xAI `web_search`** restreint au domaine pour obtenir une synthèse substantielle (700-900 chars FR-QC) vs ce que le 1er pass renvoie (souvent trop court ou passthrough des tool results).

## Files touched

| Fichier | Type |
|---|---|
| `scripts/enrichment.py` | NEW (487 lignes) |
| `prompts/enrich.txt` | NEW (39 lignes) |
| `tests/test_enrichment.py` | NEW (614 lignes, 24 tests) |
| `scripts/xai_client.py` | MODIFY (+66, optional `response_schema` + `schema_name` params) |
| `scripts/build_briefing.py` | MODIFY (+121, refactor pour partager client entre sourcing + enrichment) |
| `docs/xai-integration.md` | MODIFY (+92, nouvelle section "Enrichissement 2e passe") |
| `tests/test_xai_client.py` | MODIFY (+95, 3 tests schema override) |

**Net : +1476 lignes, -38 lignes.**

## Public API

```python
@dataclass
class EnrichmentResult:
    sections: dict[str, list[Item]]  # enriched (ou original sur skip/failure)
    dont_miss: Item | None
    warnings: list[str]
    usage: XAIUsage                  # aggregated
    enriched_count: int
    skipped_count: int

def enrich_selected(
    client: XAIClient,
    sections: dict[str, list[Item]],
    dont_miss: Item | None,
    *,
    prompts_dir: Path = Path("prompts"),
    max_workers: int = 4,
    timeout_s: float = 20.0,
) -> EnrichmentResult: ...
```

## Concurrence + garde-fous

- `ThreadPoolExecutor(max_workers=4)` — 14 items / 4 workers × ~7s = ~25s, sous le budget 30s
- Timeout par item : 20s (`future.result(timeout=...)`)
- Deadline global wall-clock : 30s à l'entrée. Futures pending au-delà → cancel + original conservé + warning
- Skip `x.com` / `twitter.com` silencieusement (redondant avec 1re passe)
- URL invalide/vide → skip avec warning
- Toute `XAIError` per-item → warning + item d'origine conservé. **Jamais d'exception au caller.**

## Schema override

`XAIClient.call()` accepte 2 nouveaux params optionnels, backward-compatible :
```python
response_schema: dict[str, Any] | None = None  # défaut ITEMS_SCHEMA
schema_name: str = "briefing_items"
```

Quand schema custom fourni, le check `"items" in parsed` est désactivé (le caller gère sa propre shape). 3 tests dédiés.

## Kill switch

Env var `BRIEFING_ENRICH=0` désactive l'enrichissement sans changement de code. Utile pour staging / debug / xAI dégradé.

## Métriques attendues en prod

| Métrique | Valeur |
|---|---|
| Appels xAI | 12 sourcing + 12-14 enrichment = **24-26/briefing** |
| Coût | +~0.10 $ enrichment → **~0.17 $/briefing, ~10 $/mois** (cible PRD ≤ 12) |
| Latence ajoutée | +20-30s parallèle 4 workers, total **60-90s wall-clock**, sous budget 180s PRD §S3 |

## Validations

- [x] `pytest -q` → **156/156 verts** (+27 vs 129)
- [x] `ruff check .` → All checks passed
- [x] `build_briefing --dry-run --fixture` → inchangé (enrichment skippé en mode fixture)

## `PROMPTS_VERSION`

Bumpée `prompts-v1.0` → **`prompts-v1.1`** (ajout de `prompts/enrich.txt`).

## À observer au prochain briefing live

1. La shape effective de la réponse `web_search` (TODO(live) marker dans code) — single-item vs array
2. La qualité effective des synthèses enrichies vs 1re passe
3. Le nombre d'items effectivement enrichis (`enriched_count` dans log stderr `enrichment_total`)
4. La latence totale (+30s ou plus ?)
5. Le coût réel vs estimation

Si la latence explose, ajustements possibles sans code change : `BRIEFING_ENRICH=0` ou baisser `max_workers` / `timeout_s` via futures env vars (extension mineure).

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo