### PR TITLE
fix(sourcing): batch web_search par 5 domaines max (closes #31)

### DIFF
--- a/docs/xai-integration.md
+++ b/docs/xai-integration.md
@@ -74,10 +74,10 @@ Toute modification du modèle doit :
 
 **Contraintes connues** (sources : `docs.x.ai`, blog xAI, GitHub openclaw/openclaw#26355) :
 
-- `allowed_x_handles` : **max 10 handles par appel** → les 15 comptes du PRD sont splittés en 2 appels (gérés par `sourcing.py`)
+- `allowed_x_handles` : **max 10 handles par appel** → les comptes X sont splittés en batches (géré par `sourcing.py` via `_chunk` + `MAX_HANDLES_PER_CALL`)
 - `allowed_x_handles` est mutuellement exclusif avec `excluded_x_handles`
+- `web_search.allowed_domains` : **max 5 domaines par appel** (issue #31, confirmé live avec 400 "A maximum of 5 domains can be allowed") → splitté en batches via `MAX_DOMAINS_PER_CALL`
 - Live Search API (legacy `search_parameters` sur `/chat/completions`) est **dépréciée 2026-01-12** (410 Gone) — on n'utilise QUE la Responses API
-- Le tool `web_search` accepte un `allowed_domains` (à confirmer en runtime)
 
 ## Forme de la réponse
 

--- a/scripts/sourcing.py
+++ b/scripts/sourcing.py
@@ -107,6 +107,11 @@ _SOURCE_TYPE_BY_TOOL: dict[str, Literal["x_account", "x_search", "web"]] = {
 # x_search avec allowed_x_handles.
 MAX_HANDLES_PER_CALL = 10
 
+# Limite xAI confirmée au premier live test post-#24 (issue #31) :
+# max 5 domaines par appel web_search avec allowed_domains. Provoque un
+# 400 "A maximum of 5 domains can be allowed" au-delà.
+MAX_DOMAINS_PER_CALL = 5
+
 # Quantités par défaut demandées au LLM (peut être tweaké via param fonction).
 DEFAULT_MAX_ACCOUNTS_TOTAL = 12
 DEFAULT_MAX_WEB_TOTAL = 8
@@ -273,45 +278,52 @@ def source_briefing(
         warnings.extend(new_warnings)
         total_usage = _add_usage(total_usage, new_usage)
 
-    # -- 3. Recherche web (UN seul appel) ----------------------------------
-    web_user_prompt = _render_prompt(
-        env,
-        "search_web.txt",
-        {
-            "allowed_domains": config["sources_web"],
-            "section_ids": section_ids,
-            "window_start_iso": window_start_iso,
-            "window_end_iso": window_end_iso,
-            "max_items_total": min(DEFAULT_MAX_WEB_TOTAL, max_items_per_call),
-        },
-    )
+    # -- 3. Recherche web (batchs de MAX_DOMAINS_PER_CALL, issue #31) ------
+    # xAI web_search plafonne à 5 domaines par appel. Même pattern que les
+    # comptes X (max 10) : on splitte en batches. N domaines / 5 → ceil appels.
+    sources_web_all = config["sources_web"]
+    web_batches = list(_chunk(sources_web_all, MAX_DOMAINS_PER_CALL))
+    for batch_idx, domains_batch in enumerate(web_batches, start=1):
+        prompt_label = f"search_web_{batch_idx}"
 
-    # TODO(live): verify web_search params — la doc xAI accessible ne fige
-    # pas le nom exact du champ (`allowed_domains` vs `domains` vs autre)
-    # ni la prise en charge de `from_date`/`to_date` côté tool.
-    web_tool_params = {
-        "allowed_domains": config["sources_web"],
-        "from_date": from_date,
-        "to_date": to_date,
-    }
+        web_user_prompt = _render_prompt(
+            env,
+            "search_web.txt",
+            {
+                "allowed_domains": domains_batch,
+                "section_ids": section_ids,
+                "window_start_iso": window_start_iso,
+                "window_end_iso": window_end_iso,
+                "max_items_total": min(DEFAULT_MAX_WEB_TOTAL, max_items_per_call),
+            },
+        )
 
-    new_items, new_warnings, new_usage = _do_call(
-        client=client,
-        system_prompt=system_prompt,
-        user_prompt=web_user_prompt,
-        tool="web_search",
-        tool_params=web_tool_params,
-        prompt_label="search_web",
-        window_start=window_start,
-        window_end=window_end,
-        valid_section_ids=valid_section_ids,
-        default_source_type="web",
-        # Web : le LLM classe, pas de default_section_id (articles couvrent
-        # politique, business, santé, etc.). Items sans section_id dropped.
-    )
-    items.extend(new_items)
-    warnings.extend(new_warnings)
-    total_usage = _add_usage(total_usage, new_usage)
+        # TODO(live): verify web_search params — la doc xAI accessible ne fige
+        # pas le nom exact du champ (`allowed_domains` vs `domains` vs autre)
+        # ni la prise en charge de `from_date`/`to_date` côté tool.
+        web_tool_params = {
+            "allowed_domains": domains_batch,
+            "from_date": from_date,
+            "to_date": to_date,
+        }
+
+        new_items, new_warnings, new_usage = _do_call(
+            client=client,
+            system_prompt=system_prompt,
+            user_prompt=web_user_prompt,
+            tool="web_search",
+            tool_params=web_tool_params,
+            prompt_label=prompt_label,
+            window_start=window_start,
+            window_end=window_end,
+            valid_section_ids=valid_section_ids,
+            default_source_type="web",
+            # Web : le LLM classe, pas de default_section_id (articles couvrent
+            # politique, business, santé, etc.). Items sans section_id dropped.
+        )
+        items.extend(new_items)
+        warnings.extend(new_warnings)
+        total_usage = _add_usage(total_usage, new_usage)
 
     return SourcingResult(items=items, warnings=warnings, total_usage=total_usage)
 

--- a/tests/test_sourcing.py
+++ b/tests/test_sourcing.py
@@ -169,7 +169,7 @@ def test_all_three_source_types_invoked(base_config, window) -> None:
     labels = [c["prompt_label"] for c in client.calls]
     assert any(label.startswith("search_accounts_") for label in labels)
     assert any(label.startswith("search_theme_") for label in labels)
-    assert "search_web" in labels
+    assert any(label.startswith("search_web_") for label in labels)
 
 
 def test_15_accounts_split_into_two_calls(base_config, window) -> None:
@@ -200,6 +200,7 @@ def test_n_themes_yields_n_calls(base_config, window) -> None:
 
 
 def test_web_yields_one_call(base_config, window) -> None:
+    """base_config a 2 domaines → 1 seul batch (≤ MAX_DOMAINS_PER_CALL=5)."""
     start, end = window
     client = StubClient(lambda i, r: _ok_response())
     source_briefing(
@@ -207,8 +208,49 @@ def test_web_yields_one_call(base_config, window) -> None:
         window_start=start, window_end=end,
         prompts_dir=PROMPTS_DIR,
     )
-    web_calls = [c for c in client.calls if c["prompt_label"] == "search_web"]
+    web_calls = [c for c in client.calls if c["prompt_label"].startswith("search_web_")]
     assert len(web_calls) == 1
+    assert web_calls[0]["prompt_label"] == "search_web_1"
+
+
+def test_web_batched_when_more_than_5_domains(base_config, window) -> None:
+    """Issue #31 : xAI web_search plafonne à 5 domaines. 8 domaines → 2 batches
+    (5 + 3), même pattern que les comptes X splittés par MAX_HANDLES_PER_CALL."""
+    start, end = window
+    cfg = {
+        **base_config,
+        "sources_web": [f"site{i}.example.com" for i in range(8)],
+    }
+    client = StubClient(lambda i, r: _ok_response())
+    source_briefing(
+        client=client, config=cfg,
+        window_start=start, window_end=end,
+        prompts_dir=PROMPTS_DIR,
+    )
+    web_calls = [c for c in client.calls if c["prompt_label"].startswith("search_web_")]
+    assert len(web_calls) == 2
+    # Chaque batch doit contenir AU PLUS 5 domaines
+    for call in web_calls:
+        domains = call["tool_params"]["allowed_domains"]
+        assert len(domains) <= 5, f"batch {call['prompt_label']} a {len(domains)} domaines"
+    # Tous les domaines doivent être couverts, sans doublon
+    all_sent = [d for call in web_calls for d in call["tool_params"]["allowed_domains"]]
+    assert sorted(all_sent) == sorted(cfg["sources_web"])
+    assert len(set(all_sent)) == len(all_sent)  # pas de doublon
+
+
+def test_web_no_call_when_sources_empty(base_config, window) -> None:
+    """sources_web vide → aucun appel web (pas de 400 avec allowed_domains=[])."""
+    start, end = window
+    cfg = {**base_config, "sources_web": []}
+    client = StubClient(lambda i, r: _ok_response())
+    source_briefing(
+        client=client, config=cfg,
+        window_start=start, window_end=end,
+        prompts_dir=PROMPTS_DIR,
+    )
+    web_calls = [c for c in client.calls if c["prompt_label"].startswith("search_web_")]
+    assert web_calls == []
 
 
 def test_total_call_count(base_config, window) -> None:
@@ -220,6 +262,8 @@ def test_total_call_count(base_config, window) -> None:
         prompts_dir=PROMPTS_DIR,
     )
     n_themes = len(base_config["recherches_thematiques"])
+    # base_config : 15 handles / 10 = 2 batches accounts + N themes + 1 web batch
+    # (2 domaines → 1 seul batch, ≤ 5)
     expected = 2 + n_themes + 1
     assert len(client.calls) == expected
 
@@ -500,10 +544,11 @@ def test_web_call_tool_params(base_config, window) -> None:
         window_start=start, window_end=end,
         prompts_dir=PROMPTS_DIR,
     )
-    web_call = next(c for c in client.calls if c["prompt_label"] == "search_web")
+    web_call = next(c for c in client.calls if c["prompt_label"].startswith("search_web_"))
     assert web_call["tool"] == "web_search"
     params = web_call["tool_params"]
     assert "allowed_domains" in params
+    # base_config a ≤ 5 domaines → un seul batch contient TOUS les domaines
     assert params["allowed_domains"] == base_config["sources_web"]
     assert "from_date" in params and "to_date" in params
 


### PR DESCRIPTION
Closes #31.

## Diagnostic

Premier test live post-#24 (8 domaines dans `sources_web`) :

```
web_search: XAIRequestError: xAI 4xx (400):
A maximum of 5 domains can be allowed, but 8 were provided.
```

xAI plafonne `allowed_domains` à **5 par appel** — contrainte analogue à `allowed_x_handles` (max 10).

## Fix (même pattern que les batches X handles)

### `scripts/sourcing.py`

```python
MAX_DOMAINS_PER_CALL = 5

# Boucle symétrique à celle des comptes X
for batch_idx, domains_batch in enumerate(_chunk(sources_web, 5), start=1):
    prompt_label = f"search_web_{batch_idx}"
    web_tool_params = {"allowed_domains": domains_batch, ...}
    _do_call(..., prompt_label=prompt_label, ...)
```

Comportement :
- ≤ 5 domaines → 1 batch (`search_web_1`)
- 6-10 domaines → 2 batches
- **0 domaines** → 0 appel (avant : 1 appel avec `allowed_domains=[]` → 400)

### Labels cohérents

`"search_web"` → `"search_web_N"` (aligné avec `"search_accounts_1/2"`).

## Tests

3 existants ajustés (label `startswith("search_web_")`) + **2 nouveaux** :

- `test_web_batched_when_more_than_5_domains` — 8 domaines → 2 batches (5+3), chaque ≤ 5, tous couverts sans doublon
- `test_web_no_call_when_sources_empty` — `sources_web=[]` → 0 appel

**158/158 verts** (+2 vs 156).

## Docs

`docs/xai-integration.md` : contrainte `web_search.allowed_domains` max 5 documentée à côté de `allowed_x_handles` max 10.

## Impact métriques prod

| Métrique | Avant fix | Après fix |
|---|---|---|
| Appels web/briefing (8 domaines) | 1 (fail 400) | **2** (5+3) |
| Items web récupérés | 0 (crash) | ~8-10 (enrichis 2e passe) |
| Coût supplémentaire/briefing | — | +~0.01 $ (négligeable) |

## Scalabilité

Linéaire via `_chunk` : 20 domaines → 4 batches, 30 → 6. Toujours sous budget même avec croissance organique des sources.

## Validations

- [x] `pytest -q` → **158/158 verts**
- [x] `ruff check .` → All checks passed
- [x] Même pattern testé/validé que `allowed_x_handles` depuis #17

https://claude.ai/code/session_01UBgsCf2afVNkv4LgpqbPwo