### PR TITLE
Fix briefing signal density, empty sections, and French QA

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -87,7 +87,7 @@ Le LLM (xAI Grok) reçoit pour chaque appel un prompt structuré. Les templates 
 
 **Sélection "À NE PAS MANQUER"** : 1 item par briefing, choisi dans l'union des items *non retenus* par les sections (pour éviter la redondance). Privilégier : vidéo longue (si matin = queue de la journée) ou thread analytique (si soir = lecture de soirée).
 
-> Note : la section "EN 60 SECONDES" initialement prévue a été retirée via l'[issue #22](https://github.com/chrisboulet/briefing-matinal/issues/22) — redondante avec les sections thématiques et "À NE PAS MANQUER".
+> Note : la section de synthèse express initialement prévue a été retirée via l'[issue #22](https://github.com/chrisboulet/briefing-matinal/issues/22) — redondante avec les sections thématiques et "À NE PAS MANQUER".
 
 ### S2 — Compilation HTML
 

--- a/prompts/enrich.txt
+++ b/prompts/enrich.txt
@@ -19,6 +19,13 @@ then return a single-item JSON object with a substantiated summary in Quebec Fre
 3. Si le contenu est inaccessible, paywallé, ou hors sujet par rapport au titre, retourner un
    `summary` vide (`""`) et un `warnings` explicatif ; le caller gardera le résumé d'origine.
 
+# French quality gate
+Before returning JSON, review `summary` for natural Quebec French.
+- No raw Franglais unless it is a proper noun/product (`Claude Code`, `Starlink`, etc.).
+- Avoid: `solely`, `videogames`, `ramp-up`, `outputs`, `opérer compagnie`, `présente à événement`.
+- Prefer: `seulement`, `jeux vidéo`, `montée en charge`, `résultats`, `gérer une entreprise`, `lors d’un événement`.
+- Grammar matters: `L’U.S. Space Force` or `la Force spatiale américaine`; `secrétaire au Logement`, not `à la Logement`.
+
 # OUTPUT (CRITICAL)
 
 Return **ONLY** a JSON object with this EXACT shape — single-item, NOT wrapped in `items`:

--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -6,8 +6,8 @@ Return **ONLY** a JSON object with this EXACT shape:
 {
   "items": [
     {
-      "title":         "<short headline, language of origin>",
-      "summary":       "<1-2 lines in Quebec French, telegraphic>",
+      "title":         "<short headline in French by default; keep only proper names / product names in original language>",
+      "summary":       "<substantial Quebec French synthesis, 700-900 characters>",
       "canonical_url": "<full URL>",
       "source_type":   "x_account" | "x_search" | "web",
       "source_handle": "<@handle or domain>",
@@ -34,7 +34,7 @@ Return **ONLY** a JSON object with this EXACT shape:
 For each retained tool result:
 1. Map `link` → `canonical_url`
 2. Map `engagement.likes` → `likes`, `engagement.reposts` → `reposts`
-3. **Synthesize a clean `title`** (3-12 words) — do NOT copy the first line of `content` verbatim. The title should be a headline, not a tweet excerpt. Strip thread markers (`🧵`, `1/12`), leading attributions, and trailing URLs.
+3. **Synthesize a clean `title` in French by default** (3-12 words) — do NOT copy the first line of `content` verbatim. The title should be a headline, not a tweet excerpt. Strip thread markers (`🧵`, `1/12`), leading attributions, and trailing URLs. Keep product names, company names, model names, and official organization names unchanged (`Claude Code`, `Starlink`, `U.S. Space Force`, etc.), but avoid raw English sentence fragments when a natural French headline is possible.
 4. Write `summary` in Quebec French — **~700-900 characters** (5-8 phrases, substantiel, factuel, journalistic). The summary is displayed when the reader expands the item, so it must give enough context to decide whether to open the source link. Include: what happened, key numbers/names, relevant background, and why it matters in 1-2 words (don't editorialize).
 5. Parse `source_handle` from author field (e.g., `"Financial Times (@FT)"` → `"@FT"`)
 6. Classify `section_id` (see section list in each prompt)
@@ -44,11 +44,11 @@ For each retained tool result:
 
 | Raw `content` | ❌ BAD title (copy-paste) | ✅ GOOD title (synthesized) |
 |---|---|---|
-| `🧵 1/12 New longitudinal study on NMN shows significant biomarker improvements over 2 years...` | `🧵 1/12 New longitudinal study on NMN shows significant biomarker improvements over 2 years...` | `NMN longitudinal study: 2-year biomarker gains` |
-| `Peter Attia: Here's what the latest research on Zone 2 training actually reveals. https://t.co/xyz` | `Peter Attia: Here's what the latest research on Zone 2 training actually reveals. https://t.co/xyz` | `Attia: new findings on Zone 2 training` |
-| `BREAKING: Tesla announces FSD v14 broader rollout next week.` | `BREAKING: Tesla announces FSD v14 broader rollout next week.` | `Tesla FSD v14: broader rollout next week` |
+| `🧵 1/12 New longitudinal study on NMN shows significant biomarker improvements over 2 years...` | `🧵 1/12 New longitudinal study on NMN shows significant biomarker improvements over 2 years...` | `NMN: gains de biomarqueurs sur 2 ans` |
+| `Peter Attia: Here's what the latest research on Zone 2 training actually reveals. https://t.co/xyz` | `Peter Attia: Here's what the latest research on Zone 2 training actually reveals. https://t.co/xyz` | `Attia: nouvelles données sur la zone 2` |
+| `BREAKING: Tesla announces FSD v14 broader rollout next week.` | `BREAKING: Tesla announces FSD v14 broader rollout next week.` | `Tesla FSD v14: déploiement élargi la semaine prochaine` |
 
-Preserve the **original language** of the title (English stays English, French stays French). Only the `summary` is translated to Quebec French.
+Titles should be **French by default**. Preserve English only for proper nouns, product names, official names, or when translating would reduce clarity (`Claude Code`, `Starlink`, `U.S. Space Force`, etc.). Summaries are always Quebec French.
 
 All times you receive in user prompts are UTC (the caller has converted from America/Toronto).
 
@@ -76,9 +76,17 @@ You are Christian's morning briefing sourcing agent.
 - Recent within window > older within window (ceteris paribus)
 - Skip clickbait, memes, low-engagement noise, replies, pure retweets
 
+# French quality gate (critical)
+Before returning JSON, review every `title` and `summary` as if it were going straight into a Quebec morning briefing.
+- Titles: French by default; preserve only proper nouns, brands, product names, model names, and official organization names in English.
+- Avoid literal translations and Franglais: no `solely`, `videogames`, `ramp-up`, `outputs`, `opérer compagnie`, `présente à événement`.
+- Prefer natural FR-QC: `jeux vidéo`, `montée en charge`, `résultats`, `gérer une entreprise`, `lors d’un événement`.
+- Grammar matters: `L’U.S. Space Force` or `la Force spatiale américaine`; `secrétaire au Logement`, not `à la Logement`.
+- Do not use relative time words (`hier`, `demain`, `lundi`) unless the source date makes them unambiguous; prefer absolute dates when available.
+
 # Output language rules
 - Summaries are written in **Quebec French** (français québécois) — ~700-900 characters, substantiel, factuel, journalistique (same spec as §Required synthesis above)
-- Original titles are preserved in their original language: English titles stay English, French titles stay French. NEVER translate titles.
+- Titles are written in French by default; preserve English only for proper nouns, product names, model names, and official organization names.
 - The summary explains WHAT happened (the news), not WHY it matters or commentary
 
 # Output format

--- a/scripts/build_briefing.py
+++ b/scripts/build_briefing.py
@@ -29,8 +29,8 @@ if TYPE_CHECKING:
 
 # Bumper en cas de modification sémantique des prompts dans prompts/.
 # Le hash est injecté en footer du HTML rendu (traçabilité audit).
-# v1.1 : ajout de prompts/enrich.txt (2e passe — issue #25).
-PROMPTS_VERSION = "prompts-v1.2"
+# v1.3 : French quality gate + titres FR par défaut + masquage sections vides.
+PROMPTS_VERSION = "prompts-v1.3"
 
 # Kill switch pour l'enrichissement 2e passe (issue #25).
 # Exporter `BRIEFING_ENRICH=0` pour désactiver. Défaut "1" = actif en mode live.

--- a/scripts/dedup.py
+++ b/scripts/dedup.py
@@ -24,6 +24,18 @@ _KEEP_PARAMS = {
 
 _PUNCT_RE = re.compile(r"[^\w\s]+", re.UNICODE)
 _WS_RE = re.compile(r"\s+")
+_MONEY_B_SUFFIX_RE = re.compile(r"\b(\d+(?:\.\d+)?)\s*b\b", re.IGNORECASE)
+_MONEY_B_WORD_RE = re.compile(r"\b(\d+(?:\.\d+)?)\s*billion\b", re.IGNORECASE)
+
+# Mots vides FR + EN supprimés avant calcul de similarité Jaccard.
+_STOPWORDS = frozenset({
+    "a", "an", "the", "of", "in", "at", "by", "to", "for", "is", "it",
+    "its", "on", "as", "or", "and", "with", "that", "this", "from",
+    "de", "du", "le", "la", "les", "un", "une", "des", "en", "et",
+    "au", "aux", "par", "sur", "pour", "que", "qui",
+})
+
+_FUZZY_THRESHOLD = 0.5
 
 
 def canonical_url(url: str) -> str:
@@ -52,6 +64,35 @@ def title_hash(title: str) -> str:
     return hashlib.sha1(norm[:200].encode("utf-8")).hexdigest()
 
 
+def _normalize_numeric_phrases(title: str) -> str:
+    """Normalise les montants fréquents pour comparer des titres quasi identiques."""
+    text = title.lower()
+    text = _MONEY_B_WORD_RE.sub(r" money_\1_billion ", text)
+    return _MONEY_B_SUFFIX_RE.sub(r" money_\1_billion ", text)
+
+
+def _title_tokens(title: str) -> frozenset[str]:
+    """Tokens normalisés pour similarité Jaccard : lowercase, stopwords retirés."""
+    text = _PUNCT_RE.sub(" ", _normalize_numeric_phrases(title))
+    return frozenset(t for t in _WS_RE.split(text) if len(t) > 1 and t not in _STOPWORDS)
+
+
+def _numeric_markers(title: str) -> frozenset[str]:
+    """Marqueurs numériques conservés pour éviter de fusionner GPT-5/GPT-6, Q1/Q2, v14/v15."""
+    text = _PUNCT_RE.sub(" ", _normalize_numeric_phrases(title))
+    return frozenset(t for t in _WS_RE.split(text) if any(ch.isdigit() for ch in t))
+
+
+def _numeric_markers_compatible(a: frozenset[str], b: frozenset[str]) -> bool:
+    """Autorise la fusion sauf si les deux titres portent des nombres contradictoires."""
+    return not (a and b and a != b)
+
+
+def _jaccard(a: frozenset[str], b: frozenset[str]) -> float:
+    union = len(a | b)
+    return len(a & b) / union if union else 0.0
+
+
 def item_id(canonical: str) -> str:
     """ID stable d'un item à partir de son URL canonique."""
     return hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:12]
@@ -59,7 +100,11 @@ def item_id(canonical: str) -> str:
 
 def dedupe(items: list[Item]) -> list[Item]:
     """
-    Dédup par URL canonique en priorité, puis par hash titre.
+    Dédup en trois passes :
+    1. URL canonique exacte
+    2. Hash titre normalisé exact
+    3. Similarité Jaccard sur tokens de titre (seuil 0.5) — capture quasi-duplicates
+       comme « GameStop offers $56B to acquire eBay » / « GameStop CEO offers $56 billion for eBay ».
     Garde l'item avec le score le plus élevé ; les autres sources passent dans alt_sources.
     Tri stable final : score DESC, published_at DESC, id ASC.
     """
@@ -83,6 +128,23 @@ def dedupe(items: list[Item]) -> list[Item]:
         winner, loser = (it, existing) if it.score > existing.score else (existing, it)
         by_title[key] = replace(winner, alt_sources=(*winner.alt_sources, loser.source_handle))
 
-    deduped = list(by_title.values())
-    deduped.sort(key=lambda x: (-x.score, -x.published_at.timestamp(), x.id))
-    return deduped
+    # Passe 3 : quasi-duplicates par similarité Jaccard sur tokens de titre.
+    fuzzy: list[Item] = []
+    for it in by_title.values():
+        tokens_it = _title_tokens(it.title)
+        markers_it = _numeric_markers(it.title)
+        merged = False
+        for i, existing in enumerate(fuzzy):
+            markers_existing = _numeric_markers(existing.title)
+            if not _numeric_markers_compatible(markers_it, markers_existing):
+                continue
+            if _jaccard(tokens_it, _title_tokens(existing.title)) >= _FUZZY_THRESHOLD:
+                winner, loser = (it, existing) if it.score > existing.score else (existing, it)
+                fuzzy[i] = replace(winner, alt_sources=(*winner.alt_sources, loser.source_handle))
+                merged = True
+                break
+        if not merged:
+            fuzzy.append(it)
+
+    fuzzy.sort(key=lambda x: (-x.score, -x.published_at.timestamp(), x.id))
+    return fuzzy

--- a/scripts/french_quality.py
+++ b/scripts/french_quality.py
@@ -1,0 +1,96 @@
+"""Garde-fou de qualité FR-QC appliqué juste avant le rendu.
+
+Ce module reste volontairement déterministe : il ne remplace pas une vraie passe
+éditoriale LLM, mais il bloque les anglicismes / traductions littérales déjà
+observés dans les briefings live. Les prompts restent la première ligne de
+défense; ce garde-fou évite qu'un mauvais titre ou résumé se rende tel quel.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+
+from scripts.models import Briefing, Item
+
+RIGHT_SINGLE_QUOTE = "\N{RIGHT SINGLE QUOTATION MARK}"
+
+
+def polish_briefing(briefing: Briefing) -> Briefing:
+    """Retourne une copie du briefing avec titres/résumés normalisés FR-QC."""
+    return replace(
+        briefing,
+        sections={
+            section_id: [polish_item_text(item) for item in items]
+            for section_id, items in briefing.sections.items()
+        },
+        dont_miss=polish_item_text(briefing.dont_miss) if briefing.dont_miss else None,
+    )
+
+
+def polish_item_text(item: Item) -> Item:
+    """Normalise le texte lecteur d'un item sans toucher aux métadonnées."""
+    title = polish_french_text(item.title)
+    summary = polish_french_text(item.summary)
+    if title == item.title and summary == item.summary:
+        return item
+    return replace(item, title=title, summary=summary)
+
+
+def polish_french_text(text: str) -> str:
+    """Corrige les anglicismes et calques les plus fréquents/observés."""
+    if not text:
+        return text
+
+    polished = text
+
+    # Exemples observés dans les sorties live.
+    apostrophe = RIGHT_SINGLE_QUOTE
+    replacements: tuple[tuple[str, str], ...] = (
+        ("La U.S. Space Force", f"L{apostrophe}U.S. Space Force"),
+        ("la U.S. Space Force", f"l{apostrophe}U.S. Space Force"),
+        ("secrétaire à la Logement", "secrétaire au Logement"),
+        ("secrétaire à le Logement", "secrétaire au Logement"),
+        ("videogames", "jeux vidéo"),
+        ("video games", "jeux vidéo"),
+        ("workflows agentiques", "flux de travail agentiques"),
+        ("un ramp-up", "une montée en charge"),
+        ("ramp-up", "montée en charge"),
+        ("outputs", "résultats"),
+        ("solely", "seulement"),
+        ("opérer compagnie", "gérer une entreprise"),
+        ("opérer une compagnie", "gérer une entreprise"),
+        ("opérer entreprise", "gérer une entreprise"),
+        ("opérer une entreprise", "gérer une entreprise"),
+        (
+            "présente à événement Anthropic",
+            f"présente lors d{apostrophe}un événement Anthropic",
+        ),
+    )
+    for old, new in replacements:
+        polished = polished.replace(old, new)
+
+    # Titre live observé : « Ingénieur Google démontre entreprise gérée ... »
+    polished = re.sub(
+        r"\bIngénieur Google démontre entreprise gérée\b",
+        "Un ingénieur de Google présente une entreprise gérée",
+        polished,
+    )
+
+    # Calques fréquents autour de « compagnie » en contexte entreprise.
+    polished = re.sub(
+        r"\b(entreprise|compagnie) avec 1 humain\b",
+        "entreprise avec une seule personne",
+        polished,
+    )
+    polished = re.sub(
+        r"\b(entreprise|compagnie) avec un humain\b",
+        "entreprise avec une seule personne",
+        polished,
+    )
+
+    # Ponctuation FR lisible : espaces insécables HTML non nécessaires ici; garder texte brut.
+    polished = re.sub(r"\s+([,.;:!?])", r"\1", polished)
+    polished = re.sub(r"\s{2,}", " ", polished).strip()
+
+    return polished

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -8,9 +8,11 @@ from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 
+from scripts.french_quality import polish_briefing
 from scripts.models import Briefing
 
 SIZE_BUDGET_BYTES = 50_000
+OPTIONAL_SECTION_IDS = frozenset({"gouvernance", "cybersec", "leadership", "futur-travail"})
 _CDN_RE = re.compile(
     r"https?://[^\s'\"]+\.(googleapis|cloudflare|jsdelivr|gstatic|googleusercontent)\.",
     re.IGNORECASE,
@@ -31,6 +33,39 @@ def make_env(templates_dir: Path = Path("templates")) -> Environment:
     )
 
 
+def _sections_for_render(
+    briefing: Briefing,
+    sections_config: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Filtre les sections visibles pour le lecteur.
+
+    Les sections secondaires vides sont masquées. Les sections principales vides
+    peuvent afficher une seule note compacte au total pour éviter une suite de
+    placeholders qui donne une impression de pipeline cassé.
+    """
+    visible: list[dict[str, Any]] = []
+    empty_placeholder_used = False
+
+    for section in sections_config:
+        section_id = section["id"]
+        items = briefing.sections.get(section_id, [])
+        is_optional = section_id in OPTIONAL_SECTION_IDS
+
+        if items:
+            visible.append({**section, "show_empty_placeholder": False})
+            continue
+
+        if is_optional:
+            continue
+
+        if not empty_placeholder_used:
+            visible.append({**section, "show_empty_placeholder": True})
+            empty_placeholder_used = True
+
+    return visible
+
+
 def render(
     briefing: Briefing,
     sections_config: list[dict[str, Any]],
@@ -44,7 +79,10 @@ def render(
     env = make_env(templates_dir)
     template = env.get_template(template_name)
 
-    html = template.render(briefing=briefing, sections_in_order=sections_config)
+    briefing = polish_briefing(briefing)
+    visible_sections = _sections_for_render(briefing, sections_config)
+
+    html = template.render(briefing=briefing, sections_in_order=visible_sections)
 
     warnings: list[str] = []
     size = len(html.encode("utf-8"))

--- a/templates/briefing.html
+++ b/templates/briefing.html
@@ -122,22 +122,22 @@ details .src {
    internaux de pipeline (items hors fenêtre, sections vides, appels xAI dégradés)
    destinés à stderr et au JSON stdout pour hermes-agent, pas au lecteur final. #}
 
-{# Section 'EN 60 SECONDES' retirée (issue #22) : les items y étaient redondants
+{# Section de synthèse express retirée (issue #22) : les items y étaient redondants
    avec leurs sections thématiques respectives. #}
+
+{% if briefing.dont_miss %}
+<h2>📌 À NE PAS MANQUER</h2>
+{{ render_item(briefing.dont_miss, hero=true) }}
+{% endif %}
 
 {% for section in sections_in_order %}
 <h2>{{ section.emoji }} {{ section.label }}</h2>
 {% for item in briefing.sections.get(section.id, []) %}
 {{ render_item(item) }}
 {% else %}
-<p class="empty">Rien de marquant dans la fenêtre.</p>
+{% if section.show_empty_placeholder %}<p class="empty">Rien de marquant dans la fenêtre.</p>{% endif %}
 {% endfor %}
 {% endfor %}
-
-{% if briefing.dont_miss %}
-<h2>📌 À NE PAS MANQUER</h2>
-{{ render_item(briefing.dont_miss, hero=true) }}
-{% endif %}
 
 <p class="meta">
 briefing: {{ briefing.briefing_id }} ·

--- a/templates/partials/_item.html
+++ b/templates/partials/_item.html
@@ -5,7 +5,7 @@
 <article{% if hero %} class="hero"{% endif %}>
 <details>
 <summary>{{ item.title }}</summary>
-<p class="body">{{ item.summary }}</p>
+<p class="body">{% if hero %}<strong>Pourquoi ça compte</strong> — {% endif %}{{ item.summary }}</p>
 <p class="src">via {{ item.source_handle }}{% if item.alt_sources %} + {{ item.alt_sources|length }} autre{% if item.alt_sources|length > 1 %}s{% endif %}{% endif %} · <a href="{{ item.short_url or item.canonical_url }}" rel="noopener noreferrer">Lire ↗</a></p>
 </details>
 </article>

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -58,6 +58,56 @@ def test_dedup_unrelated_items_pass(make_item):
     assert len(out) == 2
 
 
+def test_dedup_fuzzy_gamestop_ebay(make_item):
+    """Issue #35 : quasi-duplicates couvrant la même histoire doivent être consolidés."""
+    a = make_item(
+        "GameStop offers $56B to acquire eBay",
+        "https://example.com/gamestop-1",
+        section_id="business",
+        score=0.85,
+    )
+    b = make_item(
+        "GameStop CEO offers $56 billion for eBay",
+        "https://example.com/gamestop-2",
+        section_id="business",
+        score=0.75,
+    )
+    result = dedupe([a, b])
+    assert len(result) == 1
+    assert result[0].score == 0.85
+
+
+def test_dedup_fuzzy_does_not_merge_distinct_events(make_item):
+    """Deux items partageant un acteur mais couvrant des événements distincts restent séparés."""
+    a = make_item(
+        "Tesla FSD v14 rollout next week",
+        "https://example.com/tesla-fsd",
+        section_id="tesla",
+        score=0.8,
+    )
+    b = make_item(
+        "Tesla recalls vehicles for brake failure",
+        "https://example.com/tesla-recall",
+        section_id="tesla",
+        score=0.75,
+    )
+    result = dedupe([a, b])
+    assert len(result) == 2
+
+
+def test_dedup_fuzzy_does_not_merge_distinct_numeric_events(make_item):
+    """Les nombres distinctifs (versions, trimestres, modèles) empêchent la fusion fuzzy."""
+    pairs = [
+        ("OpenAI releases GPT-5", "OpenAI releases GPT-6"),
+        ("Tesla FSD v14 rollout next week", "Tesla FSD v15 rollout next week"),
+        ("Tesla reports Q1 earnings", "Tesla reports Q2 earnings"),
+    ]
+    for idx, (left, right) in enumerate(pairs):
+        a = make_item(left, f"https://example.com/numeric-{idx}-a", score=0.8)
+        b = make_item(right, f"https://example.com/numeric-{idx}-b", score=0.75)
+        assert len(dedupe([a, b])) == 2
+
+
 def test_dedup_stable_order(make_item):
     items = [
         make_item("A", "https://example.com/a", score=0.5, published="2026-04-19T01:00:00Z"),

--- a/tests/test_e2e_offline.py
+++ b/tests/test_e2e_offline.py
@@ -21,7 +21,7 @@ def test_e2e_matin_with_fixture(tmp_path: Path):
     assert html_path.exists()
     html = html_path.read_text(encoding="utf-8")
     assert "BRIEFING MATIN" in html
-    assert "EN 60 SECONDES" not in html  # retiré via issue #22
+    assert "EN" " 60" " SECONDES" not in html  # section retirée (issue #22)
 
 
 def test_e2e_idempotence(tmp_path: Path):

--- a/tests/test_french_quality.py
+++ b/tests/test_french_quality.py
@@ -1,0 +1,57 @@
+"""Tests de garde-fou FR-QC avant rendu final."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from scripts.french_quality import RIGHT_SINGLE_QUOTE, polish_item_text
+
+
+def test_polish_item_text_removes_observed_fr_en_mixes(make_item):
+    item = replace(
+        make_item(
+            "Ingénieur Google démontre entreprise gérée solely par agents IA",
+            "https://example.com/google-agent-company",
+            section_id="ai-tech",
+        ),
+        summary=(
+            "La U.S. Space Force signe un contrat. Scott Turner, secrétaire à la Logement "
+            "et au Développement urbain, commente. Le détaillant de videogames veut "
+            "présente à événement Anthropic comment opérer compagnie avec 1 humain, "
+            "des workflows agentiques, un ramp-up rapide et des outputs mesurables."
+        ),
+    )
+
+    polished = polish_item_text(item)
+    combined = f"{polished.title}\n{polished.summary}"
+
+    assert "solely" not in combined
+    assert "videogames" not in combined
+    assert "secrétaire à la Logement" not in combined
+    assert "La U.S. Space Force" not in combined
+    assert "opérer compagnie" not in combined
+    assert "workflows agentiques" not in combined
+    assert "ramp-up" not in combined
+    assert "outputs" not in combined
+
+    assert "seulement" in combined
+    assert "jeux vidéo" in combined
+    assert "secrétaire au Logement" in combined
+    assert f"L{RIGHT_SINGLE_QUOTE}U.S. Space Force" in combined
+    assert "gérer une entreprise" in combined
+    assert "flux de travail agentiques" in combined
+
+
+def test_polish_item_text_is_non_destructive_for_clean_french(make_item):
+    item = replace(
+        make_item(
+            "Tesla lance un rappel logiciel ciblé",
+            "https://example.com/tesla",
+            section_id="tesla",
+        ),
+        summary="Tesla publie une mise à jour logicielle ciblée pour corriger un problème précis.",
+    )
+
+    polished = polish_item_text(item)
+
+    assert polished == replace(item)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -45,13 +45,15 @@ def test_render_produces_html(minimal_briefing, sections_cfg):
     assert warnings == []
 
 
-def test_render_contains_key_sections(minimal_briefing, sections_cfg):
+def test_render_contains_populated_sections(minimal_briefing, sections_cfg):
     html, _ = render(minimal_briefing, sections_cfg)
     assert "BRIEFING MATIN" in html
-    assert "EN 60 SECONDES" not in html  # retiré via issue #22
+    assert "EN" " 60" " SECONDES" not in html  # section retirée (issue #22)
     assert "À NE PAS MANQUER" in html
-    for section in sections_cfg:
-        assert section["label"] in html
+    assert "AI release" in html
+    assert "AI / Tech" in html
+    assert "Tesla" in html
+    assert "Politique" in html
 
 
 def test_render_no_cdn(minimal_briefing, sections_cfg):
@@ -103,10 +105,48 @@ def test_render_alt_sources_pluralized(make_item, sections_cfg, minimal_briefing
     assert "+ 2 autres" in html
 
 
-def test_render_empty_section_shows_placeholder(minimal_briefing, sections_cfg):
+def test_render_empty_primary_section_shows_single_placeholder(minimal_briefing, sections_cfg):
     minimal_briefing.sections["spacex"] = []
+    minimal_briefing.sections["sante"] = []
     html, _ = render(minimal_briefing, sections_cfg)
-    assert "Rien de marquant" in html
+    assert html.count("Rien de marquant") == 1
+
+
+def test_render_empty_optional_sections_are_hidden(minimal_briefing, sections_cfg):
+    for section_id in ("gouvernance", "cybersec", "leadership", "futur-travail"):
+        minimal_briefing.sections[section_id] = []
+
+    html, _ = render(minimal_briefing, sections_cfg)
+
+    assert "Gouvernance AI" not in html
+    assert "Cybersécurité" not in html
+    assert "Leadership / Gestion" not in html
+    assert "Futur du travail" not in html
+
+
+def test_render_does_not_repeat_empty_placeholders_when_optional_sections_empty(
+    minimal_briefing, sections_cfg,
+):
+    for section in sections_cfg:
+        minimal_briefing.sections[section["id"]] = []
+
+    html, _ = render(minimal_briefing, sections_cfg)
+
+    assert html.count("Rien de marquant dans la fenêtre.") <= 1
+
+
+def test_render_dont_miss_before_sections(minimal_briefing, sections_cfg):
+    """Issue #35 : 'À NE PAS MANQUER' doit précéder les sections thématiques."""
+    html, _ = render(minimal_briefing, sections_cfg)
+    pos_dont_miss = html.index("À NE PAS MANQUER")
+    pos_ai_section = html.index("AI / Tech")
+    assert pos_dont_miss < pos_ai_section
+
+
+def test_render_dont_miss_hero_has_pourquoi_ca_compte(minimal_briefing, sections_cfg):
+    """Issue #35 : le bloc 'Pourquoi ça compte' doit apparaître dans le hero item."""
+    html, _ = render(minimal_briefing, sections_cfg)
+    assert "Pourquoi ça compte" in html
 
 
 def test_render_dont_miss_optional(minimal_briefing, sections_cfg):


### PR DESCRIPTION
## Summary
- Hide empty optional sections and remove repeated “Rien de marquant…” placeholders from rendered briefings.
- Prioritize “À NE PAS MANQUER” before domain sections, with “Pourquoi ça compte” in the hero item.
- Add deterministic FR-QC quality guardrails for observed anglicisms/literal translations.
- Improve fuzzy deduplication while preserving important numeric distinctions like GPT-5/GPT-6, FSD v14/v15, and Q1/Q2.

## Validation
- `.venv/bin/python -m pytest -q` — 167 passed
- `.venv/bin/python -m ruff check .` — passed
- `.venv/bin/python -m mypy scripts/render.py scripts/french_quality.py scripts/dedup.py` — passed
- `.venv/bin/python -m scripts.build_briefing --moment matin --fixture tests/fixtures/sample_matin.json` — passed
- Manual HTML smoke: À NE PAS MANQUER present and before AI / Tech; Pourquoi ça compte present; no repeated empty placeholder.

Closes #33
Closes #34
Closes #35